### PR TITLE
feat: Task 3 — set up Web app with React, Vite, Tailwind v4, and side…

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MediBook — Clinic Management</title>
+    <title>CareSync — Clinic Management</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,1 +1,38 @@
 @import "tailwindcss";
+
+@theme {
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(222.2 84% 4.9%);
+  --color-card: hsl(0 0% 100%);
+  --color-card-foreground: hsl(222.2 84% 4.9%);
+  --color-primary: hsl(221.2 83.2% 53.3%);
+  --color-primary-foreground: hsl(210 40% 98%);
+  --color-secondary: hsl(210 40% 96.1%);
+  --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --color-muted: hsl(210 40% 96.1%);
+  --color-muted-foreground: hsl(215.4 16.3% 46.9%);
+  --color-accent: hsl(210 40% 96.1%);
+  --color-accent-foreground: hsl(222.2 47.4% 11.2%);
+  --color-destructive: hsl(0 84.2% 60.2%);
+  --color-destructive-foreground: hsl(210 40% 98%);
+  --color-border: hsl(214.3 31.8% 91.4%);
+  --color-input: hsl(214.3 31.8% 91.4%);
+  --color-ring: hsl(221.2 83.2% 53.3%);
+  --color-sidebar: hsl(220 14% 96%);
+  --color-sidebar-foreground: hsl(222.2 84% 4.9%);
+  --radius: 0.5rem;
+}
+
+@layer base {
+  * {
+    border-color: var(--color-border);
+  }
+
+  body {
+    background-color: var(--color-background);
+    color: var(--color-foreground);
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+  }
+}

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,26 +1,15 @@
-import { Routes, Route } from "react-router";
+import { Routes, Route, Navigate } from "react-router";
+import { AppLayout } from "@/layouts/app-layout";
+import { DashboardPage } from "@/pages/dashboard";
 
 export function App() {
   return (
     <Routes>
-      <Route
-        path="/"
-        element={
-          <div className="flex min-h-screen items-center justify-center bg-gray-50">
-            <div className="text-center" data-testid="landing-page">
-              <h1 className="text-4xl font-bold text-gray-900">
-                🏥 MediBook
-              </h1>
-              <p className="mt-2 text-lg text-gray-600">
-                Healthcare Clinic Management System
-              </p>
-              <p className="mt-1 text-sm text-gray-400">
-                A practice ground for QA Automation Engineers
-              </p>
-            </div>
-          </div>
-        }
-      />
+      <Route path="/" element={<Navigate to="/dashboard" replace />} />
+      <Route element={<AppLayout />}>
+        <Route path="/dashboard" element={<DashboardPage />} />
+        {/* Additional routes will be added per task */}
+      </Route>
     </Routes>
   );
 }

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -1,0 +1,64 @@
+import { NavLink } from "react-router";
+import {
+  LayoutDashboard,
+  Calendar,
+  Stethoscope,
+  Users,
+  FileText,
+  Receipt,
+  Bell,
+  Settings,
+  HeartPulse,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const navItems = [
+  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { to: "/appointments", label: "Appointments", icon: Calendar },
+  { to: "/doctors", label: "Doctors", icon: Stethoscope },
+  { to: "/patients", label: "Patients", icon: Users },
+  { to: "/medical-records", label: "Medical Records", icon: FileText },
+  { to: "/invoices", label: "Invoices", icon: Receipt },
+  { to: "/notifications", label: "Notifications", icon: Bell },
+  { to: "/settings", label: "Settings", icon: Settings },
+];
+
+export function Sidebar() {
+  return (
+    <aside
+      className="flex h-screen w-64 flex-col border-r border-border bg-sidebar"
+      data-testid="sidebar"
+    >
+      {/* Logo */}
+      <div className="flex h-16 items-center gap-2 border-b border-border px-6">
+        <HeartPulse className="h-6 w-6 text-primary" />
+        <span className="text-lg font-semibold text-foreground">CareSync</span>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 overflow-y-auto px-3 py-4" data-testid="sidebar-nav">
+        <ul className="space-y-1">
+          {navItems.map(({ to, label, icon: Icon }) => (
+            <li key={to}>
+              <NavLink
+                to={to}
+                data-testid={`nav-${label.toLowerCase().replace(/\s+/g, "-")}`}
+                className={({ isActive }) =>
+                  cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  )
+                }
+              >
+                <Icon className="h-4 w-4 shrink-0" />
+                {label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/apps/web/src/layouts/app-layout.tsx
+++ b/apps/web/src/layouts/app-layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from "react-router";
+import { Sidebar } from "@/components/sidebar";
+
+export function AppLayout() {
+  return (
+    <div className="flex h-screen overflow-hidden" data-testid="app-layout">
+      <Sidebar />
+      <main
+        className="flex-1 overflow-y-auto bg-background p-6"
+        data-testid="main-content"
+      >
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button";
+
+export function DashboardPage() {
+  return (
+    <div data-testid="dashboard-page">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-foreground">Dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Welcome to CareSync — Healthcare Clinic Management System
+        </p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[
+          { label: "Total Patients", value: "—", testId: "stat-patients" },
+          { label: "Total Doctors", value: "—", testId: "stat-doctors" },
+          { label: "Appointments Today", value: "—", testId: "stat-appointments" },
+          { label: "Revenue (Month)", value: "—", testId: "stat-revenue" },
+        ].map(({ label, value, testId }) => (
+          <div
+            key={testId}
+            className="rounded-lg border border-border bg-card p-4 shadow-sm"
+            data-testid={testId}
+          >
+            <p className="text-sm font-medium text-muted-foreground">{label}</p>
+            <p className="mt-1 text-2xl font-bold text-card-foreground">{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Placeholder CTA */}
+      <div className="mt-8 rounded-lg border border-border bg-card p-6 text-center">
+        <p className="text-muted-foreground">
+          Full dashboard charts and stats will be available in Task 22.
+        </p>
+        <Button className="mt-4" data-testid="dashboard-cta">
+          Get Started
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…bar layout

- Fix branding from MediBook → CareSync in index.html
- Add Tailwind v4 @theme CSS variables for shadcn/ui color tokens
- Add components.json for shadcn/ui CLI support
- Create Button UI component (shadcn/ui pattern with CVA)
- Create Sidebar with navigation links and lucide-react icons
- Create AppLayout (sidebar + main content Outlet)
- Create DashboardPage placeholder with stat cards
- Wire up routing: / → /dashboard, /dashboard renders inside AppLayout
- API proxy (/api/* → http://localhost:3000) already in vite.config.ts