### PR TITLE
feat: Task 6 & 7 — auth API routes, middleware & role-based access control

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import { apiReference } from "@scalar/hono-api-reference";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { healthRoute } from "./routes/health";
+import { authRoute } from "./routes/auth";
 
 export type AppEnv = {
   Variables: {
@@ -30,6 +31,7 @@ app.get("/health", (c) =>
 
 // Routes
 app.route("/api/v1", healthRoute);
+app.route("/api/v1", authRoute);
 
 // OpenAPI spec
 app.doc("/api/openapi.json", {

--- a/apps/api/src/db/migrations/0000_flashy_prism.sql
+++ b/apps/api/src/db/migrations/0000_flashy_prism.sql
@@ -1,0 +1,169 @@
+CREATE TYPE "public"."appointment_status" AS ENUM('pending', 'confirmed', 'in-progress', 'completed', 'cancelled', 'no-show');--> statement-breakpoint
+CREATE TYPE "public"."appointment_type" AS ENUM('consultation', 'follow-up', 'emergency');--> statement-breakpoint
+CREATE TYPE "public"."day_of_week" AS ENUM('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday');--> statement-breakpoint
+CREATE TYPE "public"."gender" AS ENUM('male', 'female', 'other');--> statement-breakpoint
+CREATE TYPE "public"."invoice_status" AS ENUM('pending', 'paid', 'overdue', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."user_role" AS ENUM('admin', 'doctor', 'patient');--> statement-breakpoint
+CREATE TABLE "appointments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"patient_id" uuid NOT NULL,
+	"doctor_id" uuid NOT NULL,
+	"appointment_date" date NOT NULL,
+	"start_time" time NOT NULL,
+	"end_time" time NOT NULL,
+	"status" "appointment_status" DEFAULT 'pending' NOT NULL,
+	"type" "appointment_type" DEFAULT 'consultation' NOT NULL,
+	"reason" text,
+	"notes" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "departments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"description" text,
+	"image_url" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	CONSTRAINT "departments_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "doctor_schedules" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"doctor_id" uuid NOT NULL,
+	"day_of_week" "day_of_week" NOT NULL,
+	"start_time" time NOT NULL,
+	"end_time" time NOT NULL,
+	"slot_duration_minutes" integer DEFAULT 30 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "doctors" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"department_id" uuid NOT NULL,
+	"specialization" varchar(200) NOT NULL,
+	"bio" text,
+	"license_number" varchar(50) NOT NULL,
+	CONSTRAINT "doctors_user_id_unique" UNIQUE("user_id"),
+	CONSTRAINT "doctors_license_number_unique" UNIQUE("license_number")
+);
+--> statement-breakpoint
+CREATE TABLE "invoices" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"appointment_id" uuid NOT NULL,
+	"patient_id" uuid NOT NULL,
+	"amount" numeric(10, 2) NOT NULL,
+	"tax" numeric(10, 2) DEFAULT '0' NOT NULL,
+	"total" numeric(10, 2) NOT NULL,
+	"status" "invoice_status" DEFAULT 'pending' NOT NULL,
+	"due_date" date NOT NULL,
+	"paid_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "invoices_appointment_id_unique" UNIQUE("appointment_id")
+);
+--> statement-breakpoint
+CREATE TABLE "medical_record_attachments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"medical_record_id" uuid NOT NULL,
+	"file_name" varchar(255) NOT NULL,
+	"file_url" text NOT NULL,
+	"file_type" varchar(50) NOT NULL,
+	"file_size" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "medical_records" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"appointment_id" uuid NOT NULL,
+	"patient_id" uuid NOT NULL,
+	"doctor_id" uuid NOT NULL,
+	"diagnosis" text NOT NULL,
+	"symptoms" text,
+	"notes" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "medical_records_appointment_id_unique" UNIQUE("appointment_id")
+);
+--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"title" varchar(200) NOT NULL,
+	"message" text NOT NULL,
+	"type" varchar(50) NOT NULL,
+	"is_read" boolean DEFAULT false NOT NULL,
+	"link" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "patients" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"date_of_birth" date,
+	"gender" "gender",
+	"blood_type" varchar(5),
+	"allergies" text,
+	"emergency_contact_name" varchar(100),
+	"emergency_contact_phone" varchar(20),
+	CONSTRAINT "patients_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "prescription_items" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"prescription_id" uuid NOT NULL,
+	"medication_name" varchar(200) NOT NULL,
+	"dosage" varchar(100) NOT NULL,
+	"frequency" varchar(100) NOT NULL,
+	"duration" varchar(100) NOT NULL,
+	"instructions" text
+);
+--> statement-breakpoint
+CREATE TABLE "prescriptions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"medical_record_id" uuid NOT NULL,
+	"notes" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "reviews" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"appointment_id" uuid NOT NULL,
+	"patient_id" uuid NOT NULL,
+	"doctor_id" uuid NOT NULL,
+	"rating" integer NOT NULL,
+	"comment" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "reviews_appointment_id_unique" UNIQUE("appointment_id")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"password_hash" varchar(255) NOT NULL,
+	"role" "user_role" DEFAULT 'patient' NOT NULL,
+	"first_name" varchar(100) NOT NULL,
+	"last_name" varchar(100) NOT NULL,
+	"phone" varchar(20),
+	"avatar_url" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_patient_id_patients_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."patients"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_doctor_id_doctors_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."doctors"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctor_schedules" ADD CONSTRAINT "doctor_schedules_doctor_id_doctors_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."doctors"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctors" ADD CONSTRAINT "doctors_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doctors" ADD CONSTRAINT "doctors_department_id_departments_id_fk" FOREIGN KEY ("department_id") REFERENCES "public"."departments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_patient_id_patients_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."patients"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "medical_record_attachments" ADD CONSTRAINT "medical_record_attachments_medical_record_id_medical_records_id_fk" FOREIGN KEY ("medical_record_id") REFERENCES "public"."medical_records"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "medical_records" ADD CONSTRAINT "medical_records_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "medical_records" ADD CONSTRAINT "medical_records_patient_id_patients_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."patients"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "medical_records" ADD CONSTRAINT "medical_records_doctor_id_doctors_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."doctors"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "patients" ADD CONSTRAINT "patients_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "prescription_items" ADD CONSTRAINT "prescription_items_prescription_id_prescriptions_id_fk" FOREIGN KEY ("prescription_id") REFERENCES "public"."prescriptions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "prescriptions" ADD CONSTRAINT "prescriptions_medical_record_id_medical_records_id_fk" FOREIGN KEY ("medical_record_id") REFERENCES "public"."medical_records"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_patient_id_patients_id_fk" FOREIGN KEY ("patient_id") REFERENCES "public"."patients"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_doctor_id_doctors_id_fk" FOREIGN KEY ("doctor_id") REFERENCES "public"."doctors"("id") ON DELETE no action ON UPDATE no action;

--- a/apps/api/src/db/migrations/meta/0000_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,1184 @@
+{
+  "id": "6d4c07cf-4afb-4b09-bd18-cadc6c2e7892",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_date": {
+          "name": "appointment_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "type": {
+          "name": "type",
+          "type": "appointment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'consultation'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_doctors_id_fk": {
+          "name": "appointments_doctor_id_doctors_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "doctors",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.departments": {
+      "name": "departments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "departments_name_unique": {
+          "name": "departments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doctor_schedules": {
+      "name": "doctor_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "day_of_week",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_duration_minutes": {
+          "name": "slot_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doctor_schedules_doctor_id_doctors_id_fk": {
+          "name": "doctor_schedules_doctor_id_doctors_id_fk",
+          "tableFrom": "doctor_schedules",
+          "tableTo": "doctors",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doctors": {
+      "name": "doctors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialization": {
+          "name": "specialization",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doctors_user_id_users_id_fk": {
+          "name": "doctors_user_id_users_id_fk",
+          "tableFrom": "doctors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doctors_department_id_departments_id_fk": {
+          "name": "doctors_department_id_departments_id_fk",
+          "tableFrom": "doctors",
+          "tableTo": "departments",
+          "columnsFrom": [
+            "department_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doctors_user_id_unique": {
+          "name": "doctors_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "doctors_license_number_unique": {
+          "name": "doctors_license_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "license_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_appointment_id_unique": {
+          "name": "invoices_appointment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appointment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medical_record_attachments": {
+      "name": "medical_record_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medical_record_attachments_medical_record_id_medical_records_id_fk": {
+          "name": "medical_record_attachments_medical_record_id_medical_records_id_fk",
+          "tableFrom": "medical_record_attachments",
+          "tableTo": "medical_records",
+          "columnsFrom": [
+            "medical_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medical_records": {
+      "name": "medical_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diagnosis": {
+          "name": "diagnosis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symptoms": {
+          "name": "symptoms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medical_records_appointment_id_appointments_id_fk": {
+          "name": "medical_records_appointment_id_appointments_id_fk",
+          "tableFrom": "medical_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "medical_records_patient_id_patients_id_fk": {
+          "name": "medical_records_patient_id_patients_id_fk",
+          "tableFrom": "medical_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "medical_records_doctor_id_doctors_id_fk": {
+          "name": "medical_records_doctor_id_doctors_id_fk",
+          "tableFrom": "medical_records",
+          "tableTo": "doctors",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "medical_records_appointment_id_unique": {
+          "name": "medical_records_appointment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appointment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_type": {
+          "name": "blood_type",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "patients_user_id_users_id_fk": {
+          "name": "patients_user_id_users_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "patients_user_id_unique": {
+          "name": "patients_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_items": {
+      "name": "prescription_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prescription_items_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prescriptions_medical_record_id_medical_records_id_fk": {
+          "name": "prescriptions_medical_record_id_medical_records_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "medical_records",
+          "columnsFrom": [
+            "medical_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_appointment_id_appointments_id_fk": {
+          "name": "reviews_appointment_id_appointments_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reviews_patient_id_patients_id_fk": {
+          "name": "reviews_patient_id_patients_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reviews_doctor_id_doctors_id_fk": {
+          "name": "reviews_doctor_id_doctors_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "doctors",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_appointment_id_unique": {
+          "name": "reviews_appointment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appointment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'patient'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "in-progress",
+        "completed",
+        "cancelled",
+        "no-show"
+      ]
+    },
+    "public.appointment_type": {
+      "name": "appointment_type",
+      "schema": "public",
+      "values": [
+        "consultation",
+        "follow-up",
+        "emergency"
+      ]
+    },
+    "public.day_of_week": {
+      "name": "day_of_week",
+      "schema": "public",
+      "values": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "overdue",
+        "cancelled"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "doctor",
+        "patient"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1775803188099,
+      "tag": "0000_flashy_prism",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns, getTableName } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import {
+  users,
+  departments,
+  doctors,
+  doctorSchedules,
+  patients,
+  appointments,
+  medicalRecords,
+  medicalRecordAttachments,
+  prescriptions,
+  prescriptionItems,
+  invoices,
+  reviews,
+  notifications,
+  userRoleEnum,
+  appointmentStatusEnum,
+  appointmentTypeEnum,
+  invoiceStatusEnum,
+  genderEnum,
+  dayOfWeekEnum,
+} from "./schema";
+
+describe("Schema: table exports", () => {
+  it("exports all 13 required tables", () => {
+    expect(users).toBeDefined();
+    expect(departments).toBeDefined();
+    expect(doctors).toBeDefined();
+    expect(doctorSchedules).toBeDefined();
+    expect(patients).toBeDefined();
+    expect(appointments).toBeDefined();
+    expect(medicalRecords).toBeDefined();
+    expect(medicalRecordAttachments).toBeDefined();
+    expect(prescriptions).toBeDefined();
+    expect(prescriptionItems).toBeDefined();
+    expect(invoices).toBeDefined();
+    expect(reviews).toBeDefined();
+    expect(notifications).toBeDefined();
+  });
+
+  it("exports all 6 required enums", () => {
+    expect(userRoleEnum).toBeDefined();
+    expect(appointmentStatusEnum).toBeDefined();
+    expect(appointmentTypeEnum).toBeDefined();
+    expect(invoiceStatusEnum).toBeDefined();
+    expect(genderEnum).toBeDefined();
+    expect(dayOfWeekEnum).toBeDefined();
+  });
+});
+
+describe("Schema: table names", () => {
+  it.each([
+    [users, "users"],
+    [departments, "departments"],
+    [doctors, "doctors"],
+    [doctorSchedules, "doctor_schedules"],
+    [patients, "patients"],
+    [appointments, "appointments"],
+    [medicalRecords, "medical_records"],
+    [medicalRecordAttachments, "medical_record_attachments"],
+    [prescriptions, "prescriptions"],
+    [prescriptionItems, "prescription_items"],
+    [invoices, "invoices"],
+    [reviews, "reviews"],
+    [notifications, "notifications"],
+  ] as const)("table name is correct", (table, expectedName) => {
+    expect(getTableName(table)).toBe(expectedName);
+  });
+});
+
+describe("Schema: enum values", () => {
+  it("userRoleEnum has correct values", () => {
+    expect(userRoleEnum.enumValues).toEqual(["admin", "doctor", "patient"]);
+  });
+
+  it("appointmentStatusEnum has correct values", () => {
+    expect(appointmentStatusEnum.enumValues).toEqual([
+      "pending",
+      "confirmed",
+      "in-progress",
+      "completed",
+      "cancelled",
+      "no-show",
+    ]);
+  });
+
+  it("appointmentTypeEnum has correct values", () => {
+    expect(appointmentTypeEnum.enumValues).toEqual([
+      "consultation",
+      "follow-up",
+      "emergency",
+    ]);
+  });
+
+  it("invoiceStatusEnum has correct values", () => {
+    expect(invoiceStatusEnum.enumValues).toEqual([
+      "pending",
+      "paid",
+      "overdue",
+      "cancelled",
+    ]);
+  });
+
+  it("genderEnum has correct values", () => {
+    expect(genderEnum.enumValues).toEqual(["male", "female", "other"]);
+  });
+
+  it("dayOfWeekEnum has correct values", () => {
+    expect(dayOfWeekEnum.enumValues).toEqual([
+      "monday",
+      "tuesday",
+      "wednesday",
+      "thursday",
+      "friday",
+      "saturday",
+      "sunday",
+    ]);
+  });
+});
+
+describe("Schema: column definitions", () => {
+  it("users table has all required columns", () => {
+    const cols = getTableColumns(users);
+    expect(cols.id).toBeDefined();
+    expect(cols.email).toBeDefined();
+    expect(cols.passwordHash).toBeDefined();
+    expect(cols.role).toBeDefined();
+    expect(cols.firstName).toBeDefined();
+    expect(cols.lastName).toBeDefined();
+    expect(cols.phone).toBeDefined();
+    expect(cols.avatarUrl).toBeDefined();
+    expect(cols.isActive).toBeDefined();
+    expect(cols.createdAt).toBeDefined();
+    expect(cols.updatedAt).toBeDefined();
+  });
+
+  it("users.id is a primary key uuid with default random", () => {
+    const cols = getTableColumns(users);
+    expect(cols.id.primary).toBe(true);
+    expect(cols.id.hasDefault).toBe(true);
+  });
+
+  it("users.email is not-null and unique", () => {
+    const cols = getTableColumns(users);
+    expect(cols.email.notNull).toBe(true);
+    expect(cols.email.isUnique).toBe(true);
+  });
+
+  it("users.isActive defaults to true", () => {
+    const cols = getTableColumns(users);
+    expect(cols.isActive.hasDefault).toBe(true);
+    expect(cols.isActive.default).toBe(true);
+  });
+
+  it("departments table has all required columns", () => {
+    const cols = getTableColumns(departments);
+    expect(cols.id).toBeDefined();
+    expect(cols.name).toBeDefined();
+    expect(cols.description).toBeDefined();
+    expect(cols.imageUrl).toBeDefined();
+    expect(cols.isActive).toBeDefined();
+  });
+
+  it("doctors table has all required columns", () => {
+    const cols = getTableColumns(doctors);
+    expect(cols.id).toBeDefined();
+    expect(cols.userId).toBeDefined();
+    expect(cols.departmentId).toBeDefined();
+    expect(cols.specialization).toBeDefined();
+    expect(cols.bio).toBeDefined();
+    expect(cols.licenseNumber).toBeDefined();
+  });
+
+  it("doctors.userId is unique (one doctor profile per user)", () => {
+    const cols = getTableColumns(doctors);
+    expect(cols.userId.isUnique).toBe(true);
+  });
+
+  it("doctors.licenseNumber is unique", () => {
+    const cols = getTableColumns(doctors);
+    expect(cols.licenseNumber.isUnique).toBe(true);
+  });
+
+  it("doctorSchedules table has all required columns", () => {
+    const cols = getTableColumns(doctorSchedules);
+    expect(cols.id).toBeDefined();
+    expect(cols.doctorId).toBeDefined();
+    expect(cols.dayOfWeek).toBeDefined();
+    expect(cols.startTime).toBeDefined();
+    expect(cols.endTime).toBeDefined();
+    expect(cols.slotDurationMinutes).toBeDefined();
+  });
+
+  it("doctorSchedules.slotDurationMinutes defaults to 30", () => {
+    const cols = getTableColumns(doctorSchedules);
+    expect(cols.slotDurationMinutes.hasDefault).toBe(true);
+    expect(cols.slotDurationMinutes.default).toBe(30);
+  });
+
+  it("patients table has all required columns", () => {
+    const cols = getTableColumns(patients);
+    expect(cols.id).toBeDefined();
+    expect(cols.userId).toBeDefined();
+    expect(cols.dateOfBirth).toBeDefined();
+    expect(cols.gender).toBeDefined();
+    expect(cols.bloodType).toBeDefined();
+    expect(cols.allergies).toBeDefined();
+    expect(cols.emergencyContactName).toBeDefined();
+    expect(cols.emergencyContactPhone).toBeDefined();
+  });
+
+  it("patients.userId is unique (one patient profile per user)", () => {
+    const cols = getTableColumns(patients);
+    expect(cols.userId.isUnique).toBe(true);
+  });
+
+  it("appointments table has all required columns", () => {
+    const cols = getTableColumns(appointments);
+    expect(cols.id).toBeDefined();
+    expect(cols.patientId).toBeDefined();
+    expect(cols.doctorId).toBeDefined();
+    expect(cols.appointmentDate).toBeDefined();
+    expect(cols.startTime).toBeDefined();
+    expect(cols.endTime).toBeDefined();
+    expect(cols.status).toBeDefined();
+    expect(cols.type).toBeDefined();
+    expect(cols.reason).toBeDefined();
+    expect(cols.notes).toBeDefined();
+    expect(cols.createdAt).toBeDefined();
+    expect(cols.updatedAt).toBeDefined();
+  });
+
+  it("appointments.status defaults to pending", () => {
+    const cols = getTableColumns(appointments);
+    expect(cols.status.hasDefault).toBe(true);
+    expect(cols.status.default).toBe("pending");
+  });
+
+  it("appointments.type defaults to consultation", () => {
+    const cols = getTableColumns(appointments);
+    expect(cols.type.hasDefault).toBe(true);
+    expect(cols.type.default).toBe("consultation");
+  });
+
+  it("medicalRecords table has all required columns", () => {
+    const cols = getTableColumns(medicalRecords);
+    expect(cols.id).toBeDefined();
+    expect(cols.appointmentId).toBeDefined();
+    expect(cols.patientId).toBeDefined();
+    expect(cols.doctorId).toBeDefined();
+    expect(cols.diagnosis).toBeDefined();
+    expect(cols.symptoms).toBeDefined();
+    expect(cols.notes).toBeDefined();
+    expect(cols.createdAt).toBeDefined();
+  });
+
+  it("medicalRecords.appointmentId is unique (one record per appointment)", () => {
+    const cols = getTableColumns(medicalRecords);
+    expect(cols.appointmentId.isUnique).toBe(true);
+  });
+
+  it("medicalRecordAttachments table has all required columns", () => {
+    const cols = getTableColumns(medicalRecordAttachments);
+    expect(cols.id).toBeDefined();
+    expect(cols.medicalRecordId).toBeDefined();
+    expect(cols.fileName).toBeDefined();
+    expect(cols.fileUrl).toBeDefined();
+    expect(cols.fileType).toBeDefined();
+    expect(cols.fileSize).toBeDefined();
+  });
+
+  it("prescriptions table has all required columns", () => {
+    const cols = getTableColumns(prescriptions);
+    expect(cols.id).toBeDefined();
+    expect(cols.medicalRecordId).toBeDefined();
+    expect(cols.notes).toBeDefined();
+    expect(cols.createdAt).toBeDefined();
+  });
+
+  it("prescriptionItems table has all required columns", () => {
+    const cols = getTableColumns(prescriptionItems);
+    expect(cols.id).toBeDefined();
+    expect(cols.prescriptionId).toBeDefined();
+    expect(cols.medicationName).toBeDefined();
+    expect(cols.dosage).toBeDefined();
+    expect(cols.frequency).toBeDefined();
+    expect(cols.duration).toBeDefined();
+    expect(cols.instructions).toBeDefined();
+  });
+
+  it("invoices table has all required columns", () => {
+    const cols = getTableColumns(invoices);
+    expect(cols.id).toBeDefined();
+    expect(cols.appointmentId).toBeDefined();
+    expect(cols.patientId).toBeDefined();
+    expect(cols.amount).toBeDefined();
+    expect(cols.tax).toBeDefined();
+    expect(cols.total).toBeDefined();
+    expect(cols.status).toBeDefined();
+    expect(cols.dueDate).toBeDefined();
+    expect(cols.paidAt).toBeDefined();
+    expect(cols.createdAt).toBeDefined();
+  });
+
+  it("invoices.appointmentId is unique (one invoice per appointment)", () => {
+    const cols = getTableColumns(invoices);
+    expect(cols.appointmentId.isUnique).toBe(true);
+  });
+
+  it("invoices.status defaults to pending", () => {
+    const cols = getTableColumns(invoices);
+    expect(cols.status.hasDefault).toBe(true);
+    expect(cols.status.default).toBe("pending");
+  });
+
+  it("reviews table has all required columns", () => {
+    const cols = getTableColumns(reviews);
+    expect(cols.id).toBeDefined();
+    expect(cols.appointmentId).toBeDefined();
+    expect(cols.patientId).toBeDefined();
+    expect(cols.doctorId).toBeDefined();
+    expect(cols.rating).toBeDefined();
+    expect(cols.comment).toBeDefined();
+    expect(cols.createdAt).toBeDefined();
+  });
+
+  it("reviews.appointmentId is unique (one review per appointment)", () => {
+    const cols = getTableColumns(reviews);
+    expect(cols.appointmentId.isUnique).toBe(true);
+  });
+
+  it("notifications table has all required columns", () => {
+    const cols = getTableColumns(notifications);
+    expect(cols.id).toBeDefined();
+    expect(cols.userId).toBeDefined();
+    expect(cols.title).toBeDefined();
+    expect(cols.message).toBeDefined();
+    expect(cols.type).toBeDefined();
+    expect(cols.isRead).toBeDefined();
+    expect(cols.link).toBeDefined();
+    expect(cols.createdAt).toBeDefined();
+  });
+
+  it("notifications.isRead defaults to false", () => {
+    const cols = getTableColumns(notifications);
+    expect(cols.isRead.hasDefault).toBe(true);
+    expect(cols.isRead.default).toBe(false);
+  });
+});
+
+function getFkForColumn(table: Parameters<typeof getTableConfig>[0], columnName: string) {
+  const config = getTableConfig(table);
+  return config.foreignKeys.find((fk) =>
+    fk.reference().columns.some((col) => col.name === columnName)
+  );
+}
+
+function getFkTarget(table: Parameters<typeof getTableConfig>[0], columnName: string) {
+  const config = getTableConfig(table);
+  const fk = config.foreignKeys.find((fk) =>
+    fk.reference().columns.some((col) => col.name === columnName)
+  );
+  return fk ? fk.reference() : undefined;
+}
+
+describe("Schema: foreign key references", () => {
+  it("doctors.userId references users.id", () => {
+    const fk = getFkForColumn(doctors, "user_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("users");
+  });
+
+  it("doctors.departmentId references departments.id", () => {
+    const fk = getFkForColumn(doctors, "department_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("departments");
+  });
+
+  it("doctorSchedules.doctorId references doctors.id", () => {
+    const fk = getFkForColumn(doctorSchedules, "doctor_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("doctors");
+  });
+
+  it("patients.userId references users.id with cascade delete", () => {
+    const fk = getFkForColumn(patients, "user_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("users");
+  });
+
+  it("appointments.patientId references patients.id", () => {
+    const fk = getFkForColumn(appointments, "patient_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("patients");
+  });
+
+  it("appointments.doctorId references doctors.id", () => {
+    const fk = getFkForColumn(appointments, "doctor_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("doctors");
+  });
+
+  it("medicalRecords.appointmentId references appointments.id", () => {
+    const fk = getFkForColumn(medicalRecords, "appointment_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("appointments");
+  });
+
+  it("medicalRecordAttachments.medicalRecordId references medicalRecords.id", () => {
+    const fk = getFkForColumn(medicalRecordAttachments, "medical_record_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("medical_records");
+  });
+
+  it("prescriptions.medicalRecordId references medicalRecords.id", () => {
+    const fk = getFkForColumn(prescriptions, "medical_record_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("medical_records");
+  });
+
+  it("prescriptionItems.prescriptionId references prescriptions.id", () => {
+    const fk = getFkForColumn(prescriptionItems, "prescription_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("prescriptions");
+  });
+
+  it("invoices.appointmentId references appointments.id", () => {
+    const fk = getFkForColumn(invoices, "appointment_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("appointments");
+  });
+
+  it("invoices.patientId references patients.id", () => {
+    const fk = getFkForColumn(invoices, "patient_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("patients");
+  });
+
+  it("reviews.appointmentId references appointments.id", () => {
+    const fk = getFkForColumn(reviews, "appointment_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("appointments");
+  });
+
+  it("reviews.patientId references patients.id", () => {
+    const fk = getFkForColumn(reviews, "patient_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("patients");
+  });
+
+  it("reviews.doctorId references doctors.id", () => {
+    const fk = getFkForColumn(reviews, "doctor_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("doctors");
+  });
+
+  it("notifications.userId references users.id with cascade delete", () => {
+    const fk = getFkForColumn(notifications, "user_id");
+    expect(fk).toBeDefined();
+    expect(getTableName(fk!.reference().foreignTable)).toBe("users");
+  });
+});

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,0 +1,163 @@
+/**
+ * Database seed script — populates the database with realistic demo data
+ * for development and QA testing purposes.
+ *
+ * Usage: pnpm db:seed
+ */
+import { db } from "./index";
+import {
+  users,
+  departments,
+  doctors,
+  patients,
+  doctorSchedules,
+  appointments,
+} from "./schema";
+import bcrypt from "bcryptjs";
+
+async function seed() {
+  console.log("🌱 Seeding database...");
+
+  // --- Users ---
+  const passwordHash = await bcrypt.hash("Password123!", 10);
+
+  const [admin] = await db
+    .insert(users)
+    .values({
+      email: "admin@caresync.dev",
+      passwordHash,
+      role: "admin",
+      firstName: "Admin",
+      lastName: "User",
+      phone: "+1-555-000-0001",
+      isActive: true,
+    })
+    .returning();
+
+  const [doctorUser] = await db
+    .insert(users)
+    .values({
+      email: "dr.smith@caresync.dev",
+      passwordHash,
+      role: "doctor",
+      firstName: "John",
+      lastName: "Smith",
+      phone: "+1-555-000-0002",
+      isActive: true,
+    })
+    .returning();
+
+  const [patientUser] = await db
+    .insert(users)
+    .values({
+      email: "jane.doe@caresync.dev",
+      passwordHash,
+      role: "patient",
+      firstName: "Jane",
+      lastName: "Doe",
+      phone: "+1-555-000-0003",
+      isActive: true,
+    })
+    .returning();
+
+  console.log("  ✓ Users created");
+
+  // --- Departments ---
+  const [generalMed] = await db
+    .insert(departments)
+    .values({
+      name: "General Medicine",
+      description: "Primary care and general health consultations",
+      isActive: true,
+    })
+    .returning();
+
+  const [cardiology] = await db
+    .insert(departments)
+    .values({
+      name: "Cardiology",
+      description: "Heart and cardiovascular system specialists",
+      isActive: true,
+    })
+    .returning();
+
+  console.log("  ✓ Departments created");
+
+  // --- Doctors ---
+  const [doctor] = await db
+    .insert(doctors)
+    .values({
+      userId: doctorUser.id,
+      departmentId: generalMed.id,
+      specialization: "General Practice",
+      bio: "10+ years of experience in primary care.",
+      licenseNumber: "LIC-001234",
+    })
+    .returning();
+
+  console.log("  ✓ Doctors created");
+
+  // --- Doctor schedules (Mon–Fri, 09:00–17:00, 30-min slots) ---
+  const weekdays = [
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+  ] as const;
+
+  await db.insert(doctorSchedules).values(
+    weekdays.map((day) => ({
+      doctorId: doctor.id,
+      dayOfWeek: day,
+      startTime: "09:00",
+      endTime: "17:00",
+      slotDurationMinutes: 30,
+    }))
+  );
+
+  console.log("  ✓ Doctor schedules created");
+
+  // --- Patients ---
+  const [patient] = await db
+    .insert(patients)
+    .values({
+      userId: patientUser.id,
+      dateOfBirth: "1990-06-15",
+      gender: "female",
+      bloodType: "A+",
+      emergencyContactName: "John Doe",
+      emergencyContactPhone: "+1-555-000-0099",
+    })
+    .returning();
+
+  console.log("  ✓ Patients created");
+
+  // --- Sample appointment ---
+  await db.insert(appointments).values({
+    patientId: patient.id,
+    doctorId: doctor.id,
+    appointmentDate: "2026-04-15",
+    startTime: "10:00",
+    endTime: "10:30",
+    status: "confirmed",
+    type: "consultation",
+    reason: "Annual checkup",
+  });
+
+  console.log("  ✓ Appointments created");
+  console.log("");
+  console.log("✅ Seed complete!");
+  console.log("");
+  console.log("Demo accounts (password: Password123!):");
+  console.log(`  Admin:   ${admin.email}`);
+  console.log(`  Doctor:  ${doctorUser.email}`);
+  console.log(`  Patient: ${patientUser.email}`);
+
+  process.exit(0);
+}
+
+seed().catch((err) => {
+  console.error("❌ Seed failed:", err);
+  process.exit(1);
+});

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -3,4 +3,5 @@ export const env = {
   JWT_SECRET: process.env.JWT_SECRET || "dev-secret",
   JWT_REFRESH_SECRET: process.env.JWT_REFRESH_SECRET || "dev-refresh-secret",
   PORT: Number(process.env.PORT || 3000),
+  IS_PRODUCTION: process.env.NODE_ENV === "production",
 };

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { app } from "../app";
+
+// Mock the database to avoid needing a real PostgreSQL connection
+vi.mock("../db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+// Mock bcrypt operations — no need to run real hashing in unit tests
+vi.mock("../lib/password", () => ({
+  hashPassword: vi.fn().mockResolvedValue("$2a$10$mocked-hash"),
+  verifyPassword: vi.fn().mockResolvedValue(true),
+}));
+
+import { db } from "../db";
+import { verifyPassword } from "../lib/password";
+
+const REGISTER_URL = "/api/v1/auth/register";
+const LOGIN_URL = "/api/v1/auth/login";
+const REFRESH_URL = "/api/v1/auth/refresh";
+const LOGOUT_URL = "/api/v1/auth/logout";
+
+const mockUser = {
+  id: "user-uuid-123",
+  email: "patient@caresync.com",
+  role: "patient",
+  firstName: "John",
+  lastName: "Doe",
+  passwordHash: "$2a$10$mocked-hash",
+  phone: null,
+  isActive: true,
+  avatarUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// Helpers to build drizzle's chainable query mocks
+function makeSelectChain(result: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(result);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  return { from };
+}
+
+function makeInsertWithReturning(result: unknown[]) {
+  const returning = vi.fn().mockResolvedValue(result);
+  const values = vi.fn().mockReturnValue({ returning });
+  return { values };
+}
+
+function makeInsertVoid() {
+  const values = vi.fn().mockResolvedValue([]);
+  return { values };
+}
+
+const jsonBody = (body: object) =>
+  JSON.stringify(body);
+
+const jsonHeaders = { "Content-Type": "application/json" };
+
+describe("POST /auth/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a user and returns 201 with accessToken and user info", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+    vi.mocked(db.insert)
+      .mockReturnValueOnce(makeInsertWithReturning([mockUser]) as any)
+      .mockReturnValueOnce(makeInsertVoid() as any);
+
+    const res = await app.request(REGISTER_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "password123", firstName: "John", lastName: "Doe" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.accessToken).toBeDefined();
+    expect(body.user.id).toBe("user-uuid-123");
+    expect(body.user.email).toBe("patient@caresync.com");
+    expect(body.user.role).toBe("patient");
+    expect(body.user.firstName).toBe("John");
+    expect(body.user.lastName).toBe("Doe");
+  });
+
+  it("sets an httpOnly refreshToken cookie on successful register", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+    vi.mocked(db.insert)
+      .mockReturnValueOnce(makeInsertWithReturning([mockUser]) as any)
+      .mockReturnValueOnce(makeInsertVoid() as any);
+
+    const res = await app.request(REGISTER_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "password123", firstName: "John", lastName: "Doe" }),
+    });
+
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).toContain("refreshToken=");
+    expect(setCookie?.toLowerCase()).toContain("httponly");
+  });
+
+  it("returns 409 when the email is already registered", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeSelectChain([{ id: "existing-user" }]) as any
+    );
+
+    const res = await app.request(REGISTER_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "password123", firstName: "John", lastName: "Doe" }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.message).toBe("Email already registered");
+  });
+
+  it("returns 400 for an invalid email format", async () => {
+    const res = await app.request(REGISTER_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "not-an-email", password: "password123", firstName: "John", lastName: "Doe" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when password is shorter than 6 characters", async () => {
+    const res = await app.request(REGISTER_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "123", firstName: "John", lastName: "Doe" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when firstName is missing", async () => {
+    const res = await app.request(REGISTER_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "password123", lastName: "Doe" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /auth/login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with accessToken and sets refresh cookie on valid credentials", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([mockUser]) as any);
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+
+    const res = await app.request(LOGIN_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "password123" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accessToken).toBeDefined();
+    expect(body.user.email).toBe("patient@caresync.com");
+    expect(res.headers.get("set-cookie")).toContain("refreshToken=");
+  });
+
+  it("returns 401 when no user exists for the given email", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+
+    const res = await app.request(LOGIN_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "nobody@caresync.com", password: "password123" }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid email or password");
+  });
+
+  it("returns 401 when password is incorrect", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([mockUser]) as any);
+    vi.mocked(verifyPassword).mockResolvedValueOnce(false);
+
+    const res = await app.request(LOGIN_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "wrong-password" }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid email or password");
+  });
+
+  it("returns 401 when the account is deactivated", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeSelectChain([{ ...mockUser, isActive: false }]) as any
+    );
+
+    const res = await app.request(LOGIN_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "password123" }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Account is deactivated");
+  });
+
+  it("returns 400 for missing email", async () => {
+    const res = await app.request(LOGIN_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ password: "password123" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /auth/refresh", () => {
+  async function getRefreshToken(): Promise<string> {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([mockUser]) as any);
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    const loginRes = await app.request(LOGIN_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: jsonBody({ email: "patient@caresync.com", password: "password123" }),
+    });
+    const setCookie = loginRes.headers.get("set-cookie") ?? "";
+    return setCookie.match(/refreshToken=([^;]+)/)?.[1] ?? "";
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with a new accessToken when user is active", async () => {
+    const refreshToken = await getRefreshToken();
+    // refresh handler checks user still exists and is active
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([mockUser]) as any);
+
+    const res = await app.request(REFRESH_URL, {
+      method: "POST",
+      headers: { Cookie: `refreshToken=${refreshToken}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accessToken).toBeDefined();
+  });
+
+  it("returns 401 when the user no longer exists", async () => {
+    const refreshToken = await getRefreshToken();
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+
+    const res = await app.request(REFRESH_URL, {
+      method: "POST",
+      headers: { Cookie: `refreshToken=${refreshToken}` },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid refresh token");
+  });
+
+  it("returns 401 when the user account is deactivated", async () => {
+    const refreshToken = await getRefreshToken();
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeSelectChain([{ ...mockUser, isActive: false }]) as any
+    );
+
+    const res = await app.request(REFRESH_URL, {
+      method: "POST",
+      headers: { Cookie: `refreshToken=${refreshToken}` },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid refresh token");
+  });
+
+  it("returns 401 when no refresh cookie is present", async () => {
+    const res = await app.request(REFRESH_URL, { method: "POST" });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("No refresh token");
+  });
+
+  it("returns 401 when the refresh token is tampered", async () => {
+    const res = await app.request(REFRESH_URL, {
+      method: "POST",
+      headers: { Cookie: "refreshToken=invalid.token.here" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid refresh token");
+  });
+});
+
+describe("POST /auth/logout", () => {
+  it("returns 200 and clears the refresh cookie", async () => {
+    const res = await app.request(LOGOUT_URL, { method: "POST" });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toBe("Logged out");
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    // Cookie should be cleared (max-age=0 or expires in the past)
+    expect(setCookie).toMatch(/refreshToken=;|Max-Age=0/i);
+  });
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -9,6 +9,7 @@ import {
   signRefreshToken,
   verifyRefreshToken,
 } from "../lib/jwt";
+import { env } from "../lib/env";
 import type { AppEnv } from "../app";
 
 export const authRoute = new OpenAPIHono<AppEnv>();
@@ -60,6 +61,10 @@ const registerRoute = createRoute({
       description: "Account created",
       content: { "application/json": { schema: authResponse } },
     },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: errorResponse } },
+    },
     409: {
       description: "Email already taken",
       content: { "application/json": { schema: errorResponse } },
@@ -102,7 +107,7 @@ authRoute.openapi(registerRoute, async (c) => {
 
   setCookie(c, "refreshToken", refreshToken, {
     httpOnly: true,
-    secure: false,
+    secure: env.IS_PRODUCTION,
     sameSite: "Lax",
     maxAge: 60 * 60 * 24 * 7,
     path: "/",
@@ -136,6 +141,10 @@ const loginRoute = createRoute({
     200: {
       description: "Login successful",
       content: { "application/json": { schema: authResponse } },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: errorResponse } },
     },
     401: {
       description: "Invalid credentials",
@@ -171,7 +180,7 @@ authRoute.openapi(loginRoute, async (c) => {
 
   setCookie(c, "refreshToken", refreshToken, {
     httpOnly: true,
-    secure: false,
+    secure: env.IS_PRODUCTION,
     sameSite: "Lax",
     maxAge: 60 * 60 * 24 * 7,
     path: "/",
@@ -222,10 +231,18 @@ authRoute.openapi(refreshRoute, async (c) => {
 
   try {
     const payload = verifyRefreshToken(refreshToken);
-    const accessToken = signAccessToken({
-      userId: payload.userId,
-      role: payload.role,
-    });
+
+    const [user] = await db
+      .select({ id: users.id, role: users.role, isActive: users.isActive })
+      .from(users)
+      .where(eq(users.id, payload.userId))
+      .limit(1);
+
+    if (!user || !user.isActive) {
+      return c.json({ message: "Invalid refresh token" }, 401);
+    }
+
+    const accessToken = signAccessToken({ userId: user.id, role: user.role });
     return c.json({ accessToken }, 200);
   } catch {
     return c.json({ message: "Invalid refresh token" }, 401);


### PR DESCRIPTION
## Summary

- Implements all 4 auth endpoints under \`/api/v1/auth\`
- Implements \`GET /api/v1/users/me\` (current user profile, requires Bearer token)
- Hardens API design: 400 OpenAPI docs, env-driven \`secure\` cookie, \`/refresh\` validates user still active
- 98 tests passing (13 new tests for middleware + \`/users/me\`)

## Changes

| File | What |
|---|---|
| \`src/app.ts\` | Mount \`authRoute\` and \`usersRoute\` at \`/api/v1\` |
| \`src/lib/env.ts\` | Add \`IS_PRODUCTION\` flag |
| \`src/routes/auth.ts\` | 400 in OpenAPI spec; \`secure: env.IS_PRODUCTION\`; \`/refresh\` checks user existence + \`isActive\` |
| \`src/routes/auth.test.ts\` | 17 tests for register, login, refresh, logout |
| \`src/routes/users.ts\` | \`GET /users/me\` protected by \`requireAuth\` |
| \`src/routes/users.test.ts\` | 401 (no token, invalid, expired) + 200 with profile |
| \`src/middleware/auth.test.ts\` | \`requireAuth\` (401 cases) + \`requireRole\` (403/200, multi-role) |

## Test plan

- [ ] \`pnpm --filter @caresync/api test\` → 98 tests pass
- [ ] \`POST /api/v1/auth/register\` → 201 + access token + httpOnly refresh cookie
- [ ] \`POST /api/v1/auth/login\` → 200 or 401
- [ ] \`POST /api/v1/auth/refresh\` → rejects deleted/deactivated users
- [ ] \`POST /api/v1/auth/logout\` → clears cookie
- [ ] \`GET /api/v1/users/me\` → 401 without token, 200 with valid token
- [ ] Protected routes return 403 for wrong role

Closes #7
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)