### PR TITLE
feat: Task 8 — GET /users/me endpoint and auth middleware tests

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { healthRoute } from "./routes/health";
 import { authRoute } from "./routes/auth";
+import { usersRoute } from "./routes/users";
 
 export type AppEnv = {
   Variables: {
@@ -32,6 +33,7 @@ app.get("/health", (c) =>
 // Routes
 app.route("/api/v1", healthRoute);
 app.route("/api/v1", authRoute);
+app.route("/api/v1", usersRoute);
 
 // OpenAPI spec
 app.doc("/api/openapi.json", {

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { requireAuth, requireRole } from "./auth";
+import { signAccessToken } from "../lib/jwt";
+
+// Inline the env shape to avoid importing app.ts and its side-effects
+type TestEnv = {
+  Variables: { userId: string; userRole: string };
+};
+
+function makeTestApp() {
+  const app = new Hono<TestEnv>();
+  app.use("/protected/*", requireAuth);
+  app.use("/protected/admin/*", requireRole("admin"));
+  app.get("/protected/any", (c) => c.json({ ok: true }));
+  app.get("/protected/admin/dashboard", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function bearer(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+describe("requireAuth middleware", () => {
+  const app = makeTestApp();
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await app.request("/protected/any");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Missing or invalid authorization header");
+  });
+
+  it("returns 401 when the Authorization value does not start with 'Bearer '", async () => {
+    const res = await app.request("/protected/any", {
+      headers: { Authorization: "Basic abc123" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the token is malformed", async () => {
+    const res = await app.request("/protected/any", {
+      headers: bearer("not.a.valid.token"),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid or expired token");
+  });
+
+  it("returns 401 when the token is expired", async () => {
+    // sign with expiresIn: -1 so the token is already expired
+    const { default: jwt } = await import("jsonwebtoken");
+    const expired = jwt.sign(
+      { userId: "user-123", role: "patient" },
+      "dev-secret",
+      { expiresIn: -1 }
+    );
+    const res = await app.request("/protected/any", {
+      headers: bearer(expired),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid or expired token");
+  });
+
+  it("passes through and sets userId + userRole on context for a valid token", async () => {
+    const innerApp = new Hono<TestEnv>();
+    innerApp.use("/*", requireAuth);
+    innerApp.get("/check", (c) =>
+      c.json({ userId: c.get("userId"), userRole: c.get("userRole") })
+    );
+
+    const token = signAccessToken({ userId: "user-abc", role: "doctor" });
+    const res = await innerApp.request("/check", { headers: bearer(token) });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.userId).toBe("user-abc");
+    expect(body.userRole).toBe("doctor");
+  });
+});
+
+describe("requireRole middleware", () => {
+  const app = makeTestApp();
+
+  it("returns 403 when the authenticated user has the wrong role", async () => {
+    const patientToken = signAccessToken({ userId: "user-123", role: "patient" });
+    const res = await app.request("/protected/admin/dashboard", {
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.message).toBe("Insufficient permissions");
+  });
+
+  it("allows access when the user has the required role", async () => {
+    const adminToken = signAccessToken({ userId: "admin-123", role: "admin" });
+    const res = await app.request("/protected/admin/dashboard", {
+      headers: bearer(adminToken),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows access when the user has one of multiple accepted roles", async () => {
+    const multiApp = new Hono<TestEnv>();
+    multiApp.use("/*", requireAuth, requireRole("admin", "doctor"));
+    multiApp.get("/route", (c) => c.json({ ok: true }));
+
+    const doctorToken = signAccessToken({ userId: "doc-1", role: "doctor" });
+    const res = await multiApp.request("/route", { headers: bearer(doctorToken) });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 when none of the user's roles match the required ones", async () => {
+    const multiApp = new Hono<TestEnv>();
+    multiApp.use("/*", requireAuth, requireRole("admin", "doctor"));
+    multiApp.get("/route", (c) => c.json({ ok: true }));
+
+    const patientToken = signAccessToken({ userId: "user-1", role: "patient" });
+    const res = await multiApp.request("/route", { headers: bearer(patientToken) });
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { app } from "../app";
+import { signAccessToken } from "../lib/jwt";
+
+vi.mock("../db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/password", () => ({
+  hashPassword: vi.fn().mockResolvedValue("$2a$10$mocked-hash"),
+  verifyPassword: vi.fn().mockResolvedValue(true),
+}));
+
+import { db } from "../db";
+
+const ME_URL = "/api/v1/users/me";
+
+const mockUser = {
+  id: "user-uuid-123",
+  email: "patient@caresync.com",
+  role: "patient",
+  firstName: "John",
+  lastName: "Doe",
+  phone: null,
+  avatarUrl: null,
+  isActive: true,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+};
+
+function makeSelectChain(result: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(result);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  return { from };
+}
+
+function bearer(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+describe("GET /users/me", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    const res = await app.request(ME_URL);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Missing or invalid authorization header");
+  });
+
+  it("returns 401 when the token is invalid", async () => {
+    const res = await app.request(ME_URL, {
+      headers: bearer("not.a.valid.jwt"),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid or expired token");
+  });
+
+  it("returns 401 when the token is expired", async () => {
+    const { default: jwt } = await import("jsonwebtoken");
+    const expired = jwt.sign(
+      { userId: "user-uuid-123", role: "patient" },
+      "dev-secret",
+      { expiresIn: -1 }
+    );
+    const res = await app.request(ME_URL, { headers: bearer(expired) });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.message).toBe("Invalid or expired token");
+  });
+
+  it("returns 200 with the full user profile for a valid token", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([mockUser]) as any);
+    const token = signAccessToken({ userId: "user-uuid-123", role: "patient" });
+
+    const res = await app.request(ME_URL, { headers: bearer(token) });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("user-uuid-123");
+    expect(body.email).toBe("patient@caresync.com");
+    expect(body.role).toBe("patient");
+    expect(body.firstName).toBe("John");
+    expect(body.lastName).toBe("Doe");
+    expect(body.phone).toBeNull();
+    expect(body.isActive).toBe(true);
+    expect(body.createdAt).toBe("2024-01-01T00:00:00.000Z");
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,0 +1,77 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { users } from "../db/schema";
+import { requireAuth } from "../middleware/auth";
+import type { AppEnv } from "../app";
+
+export const usersRoute = new OpenAPIHono<AppEnv>();
+
+const meResponse = z.object({
+  id: z.string(),
+  email: z.string(),
+  role: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  phone: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  isActive: z.boolean(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+const errorResponse = z.object({ message: z.string() });
+
+const meRoute = createRoute({
+  method: "get",
+  path: "/users/me",
+  tags: ["Users"],
+  summary: "Get current user profile",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Current user profile",
+      content: { "application/json": { schema: meResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+usersRoute.use("/users/me", requireAuth);
+
+usersRoute.openapi(meRoute, async (c) => {
+  const userId = c.get("userId");
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      role: users.role,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      phone: users.phone,
+      avatarUrl: users.avatarUrl,
+      isActive: users.isActive,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!user) {
+    return c.json({ message: "User not found" }, 401);
+  }
+
+  return c.json(
+    {
+      ...user,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+    },
+    200
+  );
+});


### PR DESCRIPTION
## Summary

Completes the work from #33 that didn't make it into main before merge.

- `GET /api/v1/users/me` — returns current user profile, requires Bearer token
- Full test coverage for `requireAuth` and `requireRole` middleware
- Full test coverage for the `/users/me` endpoint

## Changes

| File | What |
|---|---|
| `src/routes/users.ts` | `GET /users/me` protected by `requireAuth`, returns full user profile |
| `src/routes/users.test.ts` | 401 (no token, invalid, expired) + 200 with profile |
| `src/middleware/auth.test.ts` | `requireAuth` (401 cases, context population) + `requireRole` (403/200, multi-role) |
| `src/app.ts` | Mount `usersRoute` at `/api/v1` |

## Test plan

- [ ] `pnpm --filter @caresync/api test` → 98 tests pass
- [ ] `GET /api/v1/users/me` without token → 401
- [ ] `GET /api/v1/users/me` with expired token → 401
- [ ] `GET /api/v1/users/me` with valid token → 200 + full profile
- [ ] Route requiring wrong role → 403

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)