### PR TITLE
ci(e2e): auto-enable GitHub Pages via configure-pages enablement flag

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,6 +90,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      administration: write
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
@@ -102,6 +103,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload report to Pages
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Adds enablement: true to actions/configure-pages so the workflow self-configures the Pages source on first run — no manual repo settings step required. Requires administration: write permission scoped to the deploy-pages job.