### PR TITLE
feat: patient profile management and admin patients list

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { authRoute } from "./routes/auth";
 import { usersRoute } from "./routes/users";
 import { departmentsRoute } from "./routes/departments";
 import { doctorsRoute } from "./routes/doctors";
+import { patientsRoute } from "./routes/patients";
 
 export type AppEnv = {
   Variables: {
@@ -42,6 +43,7 @@ app.route("/api/v1", authRoute);
 app.route("/api/v1", usersRoute);
 app.route("/api/v1", departmentsRoute);
 app.route("/api/v1", doctorsRoute);
+app.route("/api/v1", patientsRoute);
 
 // OpenAPI spec
 app.doc("/api/openapi.json", {

--- a/apps/api/src/routes/patients.test.ts
+++ b/apps/api/src/routes/patients.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { app } from "../app";
+import { signAccessToken } from "../lib/jwt";
+
+vi.mock("../db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/password", () => ({
+  hashPassword: vi.fn().mockResolvedValue("$2a$10$mocked-hash"),
+  verifyPassword: vi.fn().mockResolvedValue(true),
+}));
+
+import { db } from "../db";
+
+const ME_URL = "/api/v1/patients/me";
+
+const mockPatient = {
+  id: "patient-uuid-123",
+  userId: "user-uuid-123",
+  dateOfBirth: "1990-05-15",
+  gender: "male" as const,
+  bloodType: "A+",
+  allergies: "penicillin",
+  emergencyContactName: "Jane Doe",
+  emergencyContactPhone: "+1234567890",
+};
+
+// ─── Drizzle chain helpers ────────────────────────────────────────────────────
+
+function makeSelectChain(result: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(result);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  return { from };
+}
+
+function makeInsertWithReturning(result: unknown[]) {
+  const returning = vi.fn().mockResolvedValue(result);
+  const values = vi.fn().mockReturnValue({ returning });
+  return { values };
+}
+
+function makeUpdateChain(result: unknown[]) {
+  const returning = vi.fn().mockResolvedValue(result);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  return { set };
+}
+
+function bearer(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+const jsonHeaders = { "Content-Type": "application/json" };
+
+const patientToken = signAccessToken({
+  userId: "user-uuid-123",
+  role: "patient",
+});
+const adminToken = signAccessToken({ userId: "admin-uuid-999", role: "admin" });
+
+// ─── GET /patients/me ─────────────────────────────────────────────────────────
+
+describe("GET /patients/me", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    const res = await app.request(ME_URL);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when called by a non-patient role", async () => {
+    const res = await app.request(ME_URL, { headers: bearer(adminToken) });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns null when no patient row exists for this user", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+
+    const res = await app.request(ME_URL, { headers: bearer(patientToken) });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toBeNull();
+  });
+
+  it("returns the patient row when it exists", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeSelectChain([mockPatient]) as any
+    );
+
+    const res = await app.request(ME_URL, { headers: bearer(patientToken) });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("patient-uuid-123");
+    expect(body.userId).toBe("user-uuid-123");
+    expect(body.dateOfBirth).toBe("1990-05-15");
+    expect(body.gender).toBe("male");
+    expect(body.bloodType).toBe("A+");
+    expect(body.allergies).toBe("penicillin");
+  });
+});
+
+// ─── PUT /patients/me ─────────────────────────────────────────────────────────
+
+describe("PUT /patients/me", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const validBody = {
+    dateOfBirth: "1990-05-15",
+    gender: "male",
+    bloodType: "A+",
+    allergies: "penicillin",
+    emergencyContactName: "Jane Doe",
+    emergencyContactPhone: "+1234567890",
+  };
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: jsonHeaders,
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when called by a non-patient role", async () => {
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: { ...jsonHeaders, ...bearer(adminToken) },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("inserts a new patient row when none exists and returns 200", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(
+      makeInsertWithReturning([mockPatient]) as any
+    );
+
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("patient-uuid-123");
+    expect(body.bloodType).toBe("A+");
+  });
+
+  it("updates existing patient row and returns 200", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeSelectChain([mockPatient]) as any
+    );
+    vi.mocked(db.update).mockReturnValueOnce(
+      makeUpdateChain([{ ...mockPatient, allergies: "latex" }]) as any
+    );
+
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ ...validBody, allergies: "latex" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.allergies).toBe("latex");
+  });
+
+  it("returns 400 for an invalid blood type", async () => {
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ ...validBody, bloodType: "X+" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a future date of birth", async () => {
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ ...validBody, dateOfBirth: "2099-01-01" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when allergies exceed 1000 characters", async () => {
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ ...validBody, allergies: "a".repeat(1001) }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts null values for optional fields", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(
+      makeInsertWithReturning([
+        {
+          ...mockPatient,
+          allergies: null,
+          emergencyContactName: null,
+          emergencyContactPhone: null,
+        },
+      ]) as any
+    );
+
+    const res = await app.request(ME_URL, {
+      method: "PUT",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({
+        dateOfBirth: "1990-05-15",
+        gender: "male",
+        bloodType: "A+",
+        allergies: null,
+        emergencyContactName: null,
+        emergencyContactPhone: null,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/patients.test.ts
+++ b/apps/api/src/routes/patients.test.ts
@@ -232,3 +232,107 @@ describe("PUT /patients/me", () => {
     expect(res.status).toBe(200);
   });
 });
+
+// ─── GET /patients (admin list) ───────────────────────────────────────────────
+
+const PATIENTS_URL = "/api/v1/patients";
+const doctorToken = signAccessToken({
+  userId: "doctor-uuid-001",
+  role: "doctor",
+});
+
+const mockPatientWithUser = {
+  ...mockPatient,
+  user: {
+    id: "user-uuid-123",
+    email: "patient@example.com",
+    firstName: "John",
+    lastName: "Doe",
+  },
+};
+
+function makeJoinCountChain(total: number) {
+  const where = vi.fn().mockResolvedValue([{ total }]);
+  const innerJoin = vi.fn().mockReturnValue({ where });
+  const from = vi.fn().mockReturnValue({ innerJoin });
+  return { from };
+}
+
+function makeJoinListChain(result: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(result);
+  const offset = vi.fn().mockReturnValue({ limit });
+  const orderBy = vi.fn().mockReturnValue({ offset });
+  const where = vi.fn().mockReturnValue({ orderBy });
+  const innerJoin = vi.fn().mockReturnValue({ where });
+  const from = vi.fn().mockReturnValue({ innerJoin });
+  return { from };
+}
+
+describe("GET /patients", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    const res = await app.request(PATIENTS_URL);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when called by a non-admin role", async () => {
+    const res = await app.request(PATIENTS_URL, {
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(403);
+
+    const res2 = await app.request(PATIENTS_URL, {
+      headers: bearer(doctorToken),
+    });
+    expect(res2.status).toBe(403);
+  });
+
+  it("returns a paginated list for admin", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeJoinCountChain(1) as any)
+      .mockReturnValueOnce(makeJoinListChain([mockPatientWithUser]) as any);
+
+    const res = await app.request(PATIENTS_URL, {
+      headers: bearer(adminToken),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(1);
+    expect(body.page).toBe(1);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe("patient-uuid-123");
+    expect(body.data[0].user.email).toBe("patient@example.com");
+  });
+
+  it("accepts search, gender, and bloodType query params without error", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeJoinCountChain(0) as any)
+      .mockReturnValueOnce(makeJoinListChain([]) as any);
+
+    const res = await app.request(
+      `${PATIENTS_URL}?search=john&gender=male&bloodType=A%2B&page=1&limit=10`,
+      { headers: bearer(adminToken) }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(0);
+    expect(body.data).toHaveLength(0);
+  });
+
+  it("returns 400 for an invalid gender filter", async () => {
+    const res = await app.request(`${PATIENTS_URL}?gender=unknown`, {
+      headers: bearer(adminToken),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid bloodType filter", async () => {
+    const res = await app.request(`${PATIENTS_URL}?bloodType=X%2B`, {
+      headers: bearer(adminToken),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/patients.ts
+++ b/apps/api/src/routes/patients.ts
@@ -1,0 +1,155 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { patients } from "../db/schema";
+import { requireAuth, requireRole } from "../middleware/auth";
+import { BLOOD_TYPES, GENDERS } from "@caresync/shared";
+import type { AppEnv } from "../app";
+
+export const patientsRoute = new OpenAPIHono<AppEnv>();
+
+// ─── Shared schemas ────────────────────────────────────────────────────────────
+
+const patientResponse = z.object({
+  id: z.string(),
+  userId: z.string(),
+  dateOfBirth: z.string().nullable(),
+  gender: z.string().nullable(),
+  bloodType: z.string().nullable(),
+  allergies: z.string().nullable(),
+  emergencyContactName: z.string().nullable(),
+  emergencyContactPhone: z.string().nullable(),
+});
+
+const errorResponse = z.object({ message: z.string() });
+
+// ─── GET /patients/me ─────────────────────────────────────────────────────────
+
+const getMyPatientRoute = createRoute({
+  method: "get",
+  path: "/patients/me",
+  tags: ["Patients"],
+  summary: "Get current patient profile (null if not yet created)",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth, requireRole("patient")] as const,
+  responses: {
+    200: {
+      description: "Patient profile or null",
+      content: { "application/json": { schema: patientResponse.nullable() } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+patientsRoute.openapi(getMyPatientRoute, async (c) => {
+  const userId = c.get("userId");
+
+  const [patient] = await db
+    .select()
+    .from(patients)
+    .where(eq(patients.userId, userId))
+    .limit(1);
+
+  return c.json(patient ?? null, 200);
+});
+
+// ─── PUT /patients/me ─────────────────────────────────────────────────────────
+
+const upsertPatientBody = z.object({
+  dateOfBirth: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format")
+    .refine((val) => new Date(val) < new Date(), {
+      message: "Date of birth must be in the past",
+    })
+    .nullable()
+    .optional(),
+  gender: z.enum(GENDERS).nullable().optional(),
+  bloodType: z.enum(BLOOD_TYPES).nullable().optional(),
+  allergies: z.string().max(1000).nullable().optional(),
+  emergencyContactName: z.string().max(100).nullable().optional(),
+  emergencyContactPhone: z.string().min(1).nullable().optional(),
+});
+
+const upsertPatientRoute = createRoute({
+  method: "put",
+  path: "/patients/me",
+  tags: ["Patients"],
+  summary: "Create or update current patient medical profile",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth, requireRole("patient")] as const,
+  request: {
+    body: {
+      content: { "application/json": { schema: upsertPatientBody } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: "Upserted patient profile",
+      content: { "application/json": { schema: patientResponse } },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+patientsRoute.openapi(upsertPatientRoute, async (c) => {
+  const userId = c.get("userId");
+  const body = c.req.valid("json");
+
+  const [existing] = await db
+    .select()
+    .from(patients)
+    .where(eq(patients.userId, userId))
+    .limit(1);
+
+  if (existing) {
+    const [updated] = await db
+      .update(patients)
+      .set({
+        dateOfBirth: body.dateOfBirth ?? null,
+        gender: body.gender ?? null,
+        bloodType: body.bloodType ?? null,
+        allergies: body.allergies ?? null,
+        emergencyContactName: body.emergencyContactName ?? null,
+        emergencyContactPhone: body.emergencyContactPhone ?? null,
+      })
+      .where(eq(patients.userId, userId))
+      .returning();
+
+    return c.json(updated, 200);
+  }
+
+  const [inserted] = await db
+    .insert(patients)
+    .values({
+      userId,
+      dateOfBirth: body.dateOfBirth ?? null,
+      gender: body.gender ?? null,
+      bloodType: body.bloodType ?? null,
+      allergies: body.allergies ?? null,
+      emergencyContactName: body.emergencyContactName ?? null,
+      emergencyContactPhone: body.emergencyContactPhone ?? null,
+    })
+    .returning();
+
+  return c.json(inserted, 200);
+});

--- a/apps/api/src/routes/patients.ts
+++ b/apps/api/src/routes/patients.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { eq } from "drizzle-orm";
+import { eq, ilike, or, sql, and } from "drizzle-orm";
 import { db } from "../db";
-import { patients } from "../db/schema";
+import { patients, users } from "../db/schema";
 import { requireAuth, requireRole } from "../middleware/auth";
 import { BLOOD_TYPES, GENDERS } from "@caresync/shared";
 import type { AppEnv } from "../app";
@@ -152,4 +152,122 @@ patientsRoute.openapi(upsertPatientRoute, async (c) => {
     .returning();
 
   return c.json(inserted, 200);
+});
+
+// ─── GET /patients (admin list) ───────────────────────────────────────────────
+
+const listPatientsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1).openapi({ example: 1 }),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .openapi({ example: 20 }),
+  search: z.string().optional().openapi({ example: "john" }),
+  gender: z.enum(GENDERS).optional().openapi({ example: "male" }),
+  bloodType: z.enum(BLOOD_TYPES).optional().openapi({ example: "A+" }),
+});
+
+const patientListItem = z.object({
+  id: z.string(),
+  userId: z.string(),
+  dateOfBirth: z.string().nullable(),
+  gender: z.string().nullable(),
+  bloodType: z.string().nullable(),
+  user: z.object({
+    id: z.string(),
+    email: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+  }),
+});
+
+const paginatedPatientsResponse = z.object({
+  data: z.array(patientListItem),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+});
+
+const listPatientsRoute = createRoute({
+  method: "get",
+  path: "/patients",
+  tags: ["Patients"],
+  summary: "List all patients with search and filters (admin only)",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth, requireRole("admin")] as const,
+  request: { query: listPatientsQuerySchema },
+  responses: {
+    200: {
+      description: "Paginated patient list",
+      content: { "application/json": { schema: paginatedPatientsResponse } },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+patientsRoute.openapi(listPatientsRoute, async (c) => {
+  const { page, limit, search, gender, bloodType } = c.req.valid("query");
+  const offset = (page - 1) * limit;
+
+  const conditions = [];
+  if (search) {
+    conditions.push(
+      or(
+        ilike(users.firstName, `%${search}%`),
+        ilike(users.lastName, `%${search}%`),
+        ilike(users.email, `%${search}%`)
+      )
+    );
+  }
+  if (gender) conditions.push(eq(patients.gender, gender));
+  if (bloodType) conditions.push(eq(patients.bloodType, bloodType));
+
+  const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [{ total }] = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(patients)
+    .innerJoin(users, eq(patients.userId, users.id))
+    .where(whereCondition);
+
+  const rows = await db
+    .select({
+      id: patients.id,
+      userId: patients.userId,
+      dateOfBirth: patients.dateOfBirth,
+      gender: patients.gender,
+      bloodType: patients.bloodType,
+      user: {
+        id: users.id,
+        email: users.email,
+        firstName: users.firstName,
+        lastName: users.lastName,
+      },
+    })
+    .from(patients)
+    .innerJoin(users, eq(patients.userId, users.id))
+    .where(whereCondition)
+    .orderBy(users.lastName)
+    .offset(offset)
+    .limit(limit);
+
+  return c.json(
+    { data: rows, total, page, limit, totalPages: Math.ceil(total / limit) },
+    200
+  );
 });

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig, devices } from '@playwright/test';
-import path from 'node:path';
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
 
 // Load .env from the e2e package root (Node 20.6+ built-in, no dotenv dependency needed).
 // Falls back silently when the file doesn't exist (e.g. CI sets vars directly).
 try {
-  process.loadEnvFile(path.resolve(__dirname, '.env'));
+  process.loadEnvFile(path.resolve(__dirname, ".env"));
 } catch {
   // .env not present — relying on environment variables already set
 }
@@ -13,38 +13,40 @@ try {
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 2 : undefined,
+  /* Retry once locally too, as network timing can vary */
+  retries: process.env.CI ? 2 : 1,
+  /* Cap workers at 2 locally and on CI to prevent DB saturation under parallel load. */
+  workers: 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['github'], ['html']] : [['html', { open: 'never' }]],
+  reporter: process.env.CI
+    ? [["github"], ["html"]]
+    : [["html", { open: "never" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.BASE_URL || 'http://localhost:5173',
+    baseURL: process.env.BASE_URL || "http://localhost:5173",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
   ],
 
   /* Run local dev server before starting the tests in CI */
   webServer: {
-    command: 'cd ../.. && pnpm run dev',
-    url: 'http://localhost:5173',
+    command: "cd ../.. && pnpm run dev",
+    url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },

--- a/apps/e2e/tests/patient-profile.spec.ts
+++ b/apps/e2e/tests/patient-profile.spec.ts
@@ -1,0 +1,259 @@
+import { test, expect } from "./utils/test-base";
+import { faker } from "@faker-js/faker";
+import { config } from "./utils/config";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function registerPatientAndLogin(
+  request: any,
+  page: any,
+  loginPage: any,
+  cleanup: any
+) {
+  const user = {
+    email: faker.internet.email().toLowerCase(),
+    password: faker.internet.password({ length: 12 }) + "A!",
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+  };
+
+  const res = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+    data: { role: "patient", ...user },
+  });
+  expect(res.ok()).toBeTruthy();
+  const { user: created } = await res.json();
+  cleanup.addUser(created.id);
+
+  await loginPage.goto();
+  await loginPage.login(user.email, user.password);
+  await page.waitForURL("/dashboard");
+
+  return { user, userId: created.id };
+}
+
+// ─── Medical Information section (patient) ───────────────────────────────────
+
+test.describe("Patient Medical Profile", () => {
+  test.beforeEach(async ({ page, request, loginPage, cleanup }) => {
+    await registerPatientAndLogin(request, page, loginPage, cleanup);
+    await page.goto("/profile");
+  });
+
+  test("PP-1: Medical Information section is visible for patients", async ({
+    profilePage,
+  }) => {
+    await profilePage.isLoaded();
+    await expect(profilePage.medicalInfoSection).toBeVisible();
+  });
+
+  test("PP-2: All medical fields are present", async ({ profilePage }) => {
+    await profilePage.isLoaded();
+    await expect(profilePage.dobInput).toBeVisible();
+    await expect(profilePage.genderSelect).toBeVisible();
+    await expect(profilePage.bloodTypeSelect).toBeVisible();
+    await expect(profilePage.allergiesInput).toBeVisible();
+    await expect(profilePage.emergencyContactNameInput).toBeVisible();
+    await expect(profilePage.emergencyContactPhoneInput).toBeVisible();
+    await expect(profilePage.saveMedicalButton).toBeVisible();
+  });
+
+  test("PP-3: Saving medical info shows success message", async ({
+    profilePage,
+  }) => {
+    await profilePage.isLoaded();
+
+    await profilePage.dobInput.fill("1990-05-15");
+    await profilePage.genderSelect.selectOption("male");
+    await profilePage.bloodTypeSelect.selectOption("A+");
+    await profilePage.allergiesInput.fill("penicillin");
+    await profilePage.emergencyContactNameInput.fill("Jane Doe");
+    await profilePage.emergencyContactPhoneInput.fill("+1234567890");
+
+    await profilePage.saveMedicalButton.click();
+
+    await expect(profilePage.medicalSuccessMessage).toBeVisible();
+    await expect(profilePage.medicalSuccessMessage).toContainText(
+      /updated successfully/i
+    );
+  });
+
+  test("PP-4: Saved medical data persists after page reload", async ({
+    page,
+    profilePage,
+  }) => {
+    await profilePage.isLoaded();
+
+    await profilePage.dobInput.fill("1985-11-22");
+    await profilePage.genderSelect.selectOption("female");
+    await profilePage.bloodTypeSelect.selectOption("O-");
+    await profilePage.allergiesInput.fill("latex");
+    await profilePage.saveMedicalButton.click();
+    await expect(profilePage.medicalSuccessMessage).toBeVisible();
+
+    await page.reload();
+    await profilePage.isLoaded();
+
+    await expect(profilePage.dobInput).toHaveValue("1985-11-22");
+    await expect(profilePage.genderSelect).toHaveValue("female");
+    await expect(profilePage.bloodTypeSelect).toHaveValue("O-");
+    await expect(profilePage.allergiesInput).toHaveValue("latex");
+  });
+
+  test("PP-5: Medical info fields start empty for a new patient", async ({
+    profilePage,
+  }) => {
+    await profilePage.isLoaded();
+
+    await expect(profilePage.dobInput).toHaveValue("");
+    await expect(profilePage.genderSelect).toHaveValue("");
+    await expect(profilePage.bloodTypeSelect).toHaveValue("");
+    await expect(profilePage.allergiesInput).toHaveValue("");
+  });
+});
+
+// ─── Non-patient role: medical section hidden ─────────────────────────────────
+
+test.describe("Patient Medical Profile — admin role", () => {
+  test("PP-6: Medical Information section is NOT visible for admin", async ({
+    page,
+    profilePage,
+    loginPage,
+  }) => {
+    test.skip(
+      !config.adminEmail,
+      "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars to run admin tests"
+    );
+
+    await loginPage.goto();
+    await loginPage.login(config.adminEmail, config.adminPassword);
+    await page.waitForURL("/dashboard");
+    await page.goto("/profile");
+    await profilePage.isLoaded();
+
+    await expect(profilePage.medicalInfoSection).not.toBeVisible();
+  });
+});
+
+// ─── API-level tests ──────────────────────────────────────────────────────────
+
+test.describe("Patient Profile — API", () => {
+  test("PP-A1: GET /patients/me returns empty record for a new patient", async ({
+    request,
+    cleanup,
+  }) => {
+    const user = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...user },
+    });
+    const { accessToken, user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    const res = await request.get(`${config.apiUrl}/api/v1/patients/me`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    // Registration auto-creates a patient row; all clinical fields start null
+    expect(body).toMatchObject({
+      dateOfBirth: null,
+      gender: null,
+      bloodType: null,
+      allergies: null,
+      emergencyContactName: null,
+      emergencyContactPhone: null,
+    });
+  });
+
+  test("PP-A2: PUT /patients/me upserts patient data", async ({
+    request,
+    cleanup,
+  }) => {
+    const user = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...user },
+    });
+    const { accessToken, user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    const putRes = await request.put(`${config.apiUrl}/api/v1/patients/me`, {
+      data: {
+        dateOfBirth: "1990-05-15",
+        gender: "male",
+        bloodType: "A+",
+        allergies: "penicillin",
+        emergencyContactName: "Jane Doe",
+        emergencyContactPhone: "+1234567890",
+      },
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(putRes.status()).toBe(200);
+    const body = await putRes.json();
+    expect(body.dateOfBirth).toBe("1990-05-15");
+    expect(body.gender).toBe("male");
+    expect(body.bloodType).toBe("A+");
+  });
+
+  test("PP-A3: PUT /patients/me rejects an invalid blood type", async ({
+    request,
+    cleanup,
+  }) => {
+    const user = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...user },
+    });
+    const { accessToken, user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    const res = await request.put(`${config.apiUrl}/api/v1/patients/me`, {
+      data: { bloodType: "X+" },
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.status()).toBe(400);
+  });
+
+  test("PP-A4: PUT /patients/me rejects a future date of birth", async ({
+    request,
+    cleanup,
+  }) => {
+    const user = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...user },
+    });
+    const { accessToken, user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    const res = await request.put(`${config.apiUrl}/api/v1/patients/me`, {
+      data: { dateOfBirth: "2099-01-01" },
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.status()).toBe(400);
+  });
+});

--- a/apps/e2e/tests/patients.spec.ts
+++ b/apps/e2e/tests/patients.spec.ts
@@ -1,0 +1,258 @@
+import { test, expect } from "./utils/test-base";
+import { faker } from "@faker-js/faker";
+import { config } from "./utils/config";
+
+// ─── Admin patients list ───────────────────────────────────────────────────────
+
+test.describe("Patients List — admin view", () => {
+  test.beforeEach(async ({ page, loginPage }) => {
+    test.skip(
+      !config.adminEmail,
+      "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars to run admin tests"
+    );
+
+    await loginPage.goto();
+    await loginPage.login(config.adminEmail, config.adminPassword);
+    await page.waitForURL("/dashboard");
+  });
+
+  test("PAT-1: Admin can navigate to /patients via sidebar", async ({
+    page,
+    patientsPage,
+  }) => {
+    await page.getByTestId("nav-patients").click();
+    await page.waitForURL("/patients");
+    await patientsPage.isLoaded();
+    await expect(
+      page.getByRole("heading", { name: /patients/i })
+    ).toBeVisible();
+  });
+
+  test("PAT-2: /patients page renders search and filter controls", async ({
+    patientsPage,
+  }) => {
+    await patientsPage.goto();
+    await patientsPage.isLoaded();
+
+    await expect(patientsPage.searchInput).toBeVisible();
+    await expect(patientsPage.genderFilter).toBeVisible();
+    await expect(patientsPage.bloodTypeFilter).toBeVisible();
+  });
+
+  test("PAT-3: Patients list shows registered patients", async ({
+    request,
+    cleanup,
+    patientsPage,
+  }) => {
+    // Register a fresh patient so we know at least one exists
+    const patient = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...patient },
+    });
+    const { user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    await patientsPage.goto();
+    await patientsPage.isLoaded();
+
+    // At least one row should exist
+    await expect(patientsPage.emptyState).not.toBeVisible();
+    await expect(patientsPage.paginationInfo).toBeVisible();
+  });
+
+  test("PAT-4: Search filters the list by patient name", async ({
+    request,
+    cleanup,
+    page,
+    patientsPage,
+  }) => {
+    const uniqueFirstName = `E2E${faker.string.alphanumeric(8)}`;
+    const patient = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: uniqueFirstName,
+      lastName: faker.person.lastName(),
+    };
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...patient },
+    });
+    const { user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    await patientsPage.goto();
+    await patientsPage.isLoaded();
+
+    // Wait for the search response to arrive before asserting
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/v1/patients") && resp.status() === 200
+      ),
+      patientsPage.searchInput.fill(uniqueFirstName),
+    ]);
+
+    await expect(page.getByText(uniqueFirstName)).toBeVisible();
+  });
+
+  test("PAT-5: Gender filter dropdown contains all gender options", async ({
+    patientsPage,
+  }) => {
+    await patientsPage.goto();
+    await patientsPage.isLoaded();
+
+    const options = await patientsPage.genderFilter
+      .locator("option")
+      .allTextContents();
+    expect(options).toContain("Male");
+    expect(options).toContain("Female");
+    expect(options).toContain("Other");
+  });
+
+  test("PAT-6: Blood type filter dropdown contains all blood type options", async ({
+    patientsPage,
+  }) => {
+    await patientsPage.goto();
+    await patientsPage.isLoaded();
+
+    const options = await patientsPage.bloodTypeFilter
+      .locator("option")
+      .allTextContents();
+    for (const bt of ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"]) {
+      expect(options).toContain(bt);
+    }
+  });
+});
+
+// ─── Non-admin access ─────────────────────────────────────────────────────────
+
+test.describe("Patients List — non-admin access", () => {
+  test("PAT-7: Patients sidebar link is NOT visible for patient role", async ({
+    page,
+    request,
+    loginPage,
+    cleanup,
+  }) => {
+    const user = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...user },
+    });
+    const { user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    await loginPage.goto();
+    await loginPage.login(user.email, user.password);
+    await page.waitForURL("/dashboard");
+
+    await expect(page.getByTestId("nav-patients")).not.toBeVisible();
+  });
+
+  test("PAT-8: GET /patients returns 403 for patient role", async ({
+    request,
+    cleanup,
+  }) => {
+    const user = {
+      email: faker.internet.email().toLowerCase(),
+      password: faker.internet.password({ length: 12 }) + "A!",
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+    const regRes = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+      data: { role: "patient", ...user },
+    });
+    const { accessToken, user: created } = await regRes.json();
+    cleanup.addUser(created.id);
+
+    const res = await request.get(`${config.apiUrl}/api/v1/patients`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.status()).toBe(403);
+  });
+});
+
+// ─── Admin API tests ──────────────────────────────────────────────────────────
+
+test.describe("Patients List — API (admin)", () => {
+  test("PAT-A1: GET /patients returns paginated list for admin", async ({
+    request,
+  }) => {
+    test.skip(
+      !config.adminEmail,
+      "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars to run admin tests"
+    );
+
+    const loginRes = await request.post(`${config.apiUrl}/api/v1/auth/login`, {
+      data: { email: config.adminEmail, password: config.adminPassword },
+    });
+    const { accessToken } = await loginRes.json();
+
+    const res = await request.get(`${config.apiUrl}/api/v1/patients`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      data: expect.any(Array),
+      total: expect.any(Number),
+      page: 1,
+      limit: 20,
+      totalPages: expect.any(Number),
+    });
+  });
+
+  test("PAT-A2: GET /patients supports gender filter", async ({ request }) => {
+    test.skip(
+      !config.adminEmail,
+      "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars to run admin tests"
+    );
+
+    const loginRes = await request.post(`${config.apiUrl}/api/v1/auth/login`, {
+      data: { email: config.adminEmail, password: config.adminPassword },
+    });
+    const { accessToken } = await loginRes.json();
+
+    const res = await request.get(
+      `${config.apiUrl}/api/v1/patients?gender=male`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    // Every returned row must have gender=male (or none if empty)
+    for (const patient of body.data) {
+      expect(patient.gender).toBe("male");
+    }
+  });
+
+  test("PAT-A3: GET /patients rejects invalid gender filter with 400", async ({
+    request,
+  }) => {
+    test.skip(
+      !config.adminEmail,
+      "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars to run admin tests"
+    );
+
+    const loginRes = await request.post(`${config.apiUrl}/api/v1/auth/login`, {
+      data: { email: config.adminEmail, password: config.adminPassword },
+    });
+    const { accessToken } = await loginRes.json();
+
+    const res = await request.get(
+      `${config.apiUrl}/api/v1/patients?gender=unknown`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+
+    expect(res.status()).toBe(400);
+  });
+});

--- a/apps/e2e/tests/poms/PatientsPage.ts
+++ b/apps/e2e/tests/poms/PatientsPage.ts
@@ -1,0 +1,33 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class PatientsPage {
+  readonly page: Page;
+  readonly pageWrapper: Locator;
+  readonly searchInput: Locator;
+  readonly genderFilter: Locator;
+  readonly bloodTypeFilter: Locator;
+  readonly emptyState: Locator;
+  readonly paginationInfo: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.pageWrapper = page.getByTestId("patients-page");
+    this.searchInput = page.getByTestId("search-input");
+    this.genderFilter = page.getByTestId("gender-filter");
+    this.bloodTypeFilter = page.getByTestId("blood-type-filter");
+    this.emptyState = page.getByTestId("patients-empty");
+    this.paginationInfo = page.getByTestId("pagination-info");
+  }
+
+  async goto() {
+    await this.page.goto("/patients");
+  }
+
+  async isLoaded() {
+    await this.pageWrapper.waitFor({ state: "visible" });
+  }
+
+  patientRow(id: string) {
+    return this.page.getByTestId(`patient-row-${id}`);
+  }
+}

--- a/apps/e2e/tests/poms/ProfilePage.ts
+++ b/apps/e2e/tests/poms/ProfilePage.ts
@@ -1,4 +1,4 @@
-import { type Locator, type Page } from '@playwright/test';
+import { type Locator, type Page } from "@playwright/test";
 
 export class ProfilePage {
   readonly page: Page;
@@ -16,29 +16,56 @@ export class ProfilePage {
   readonly firstNameError: Locator;
   readonly lastNameError: Locator;
 
+  // Medical information section (patient role only)
+  readonly medicalInfoSection: Locator;
+  readonly dobInput: Locator;
+  readonly genderSelect: Locator;
+  readonly bloodTypeSelect: Locator;
+  readonly allergiesInput: Locator;
+  readonly emergencyContactNameInput: Locator;
+  readonly emergencyContactPhoneInput: Locator;
+  readonly saveMedicalButton: Locator;
+  readonly medicalSuccessMessage: Locator;
+  readonly medicalErrorMessage: Locator;
+
   constructor(page: Page) {
     this.page = page;
-    this.pageWrapper = page.getByTestId('profile-page');
-    this.firstNameInput = page.getByTestId('first-name-input');
-    this.lastNameInput = page.getByTestId('last-name-input');
-    this.phoneInput = page.getByTestId('phone-input');
-    this.saveButton = page.getByTestId('save-profile-button');
-    this.successMessage = page.getByTestId('profile-success');
-    this.errorMessage = page.getByTestId('profile-error');
-    this.avatarUploadInput = page.getByTestId('avatar-upload-input');
-    this.avatarUploadButton = page.getByTestId('avatar-upload-button');
-    this.avatarInitials = page.getByTestId('avatar-initials');
-    this.avatarImage = page.getByTestId('avatar-image');
-    this.firstNameError = page.getByTestId('first-name-error');
-    this.lastNameError = page.getByTestId('last-name-error');
+    this.pageWrapper = page.getByTestId("profile-page");
+    this.firstNameInput = page.getByTestId("first-name-input");
+    this.lastNameInput = page.getByTestId("last-name-input");
+    this.phoneInput = page.getByTestId("phone-input");
+    this.saveButton = page.getByTestId("save-profile-button");
+    this.successMessage = page.getByTestId("profile-success");
+    this.errorMessage = page.getByTestId("profile-error");
+    this.avatarUploadInput = page.getByTestId("avatar-upload-input");
+    this.avatarUploadButton = page.getByTestId("avatar-upload-button");
+    this.avatarInitials = page.getByTestId("avatar-initials");
+    this.avatarImage = page.getByTestId("avatar-image");
+    this.firstNameError = page.getByTestId("first-name-error");
+    this.lastNameError = page.getByTestId("last-name-error");
+
+    this.medicalInfoSection = page.getByTestId("medical-info-section");
+    this.dobInput = page.getByTestId("dob-input");
+    this.genderSelect = page.getByTestId("gender-select");
+    this.bloodTypeSelect = page.getByTestId("blood-type-select");
+    this.allergiesInput = page.getByTestId("allergies-input");
+    this.emergencyContactNameInput = page.getByTestId(
+      "emergency-contact-name-input"
+    );
+    this.emergencyContactPhoneInput = page.getByTestId(
+      "emergency-contact-phone-input"
+    );
+    this.saveMedicalButton = page.getByTestId("save-medical-button");
+    this.medicalSuccessMessage = page.getByTestId("medical-success");
+    this.medicalErrorMessage = page.getByTestId("medical-error");
   }
 
   async goto() {
-    await this.page.goto('/profile');
+    await this.page.goto("/profile");
   }
 
   async isLoaded() {
-    await this.pageWrapper.waitFor({ state: 'visible' });
+    await this.pageWrapper.waitFor({ state: "visible" });
   }
 
   async updateProfile(firstName: string, lastName: string, phone?: string) {
@@ -50,7 +77,11 @@ export class ProfilePage {
     await this.saveButton.click();
   }
 
-  async uploadAvatar(buffer: Buffer, filename = 'avatar.jpg', mimeType = 'image/jpeg') {
+  async uploadAvatar(
+    buffer: Buffer,
+    filename = "avatar.jpg",
+    mimeType = "image/jpeg"
+  ) {
     await this.avatarUploadInput.setInputFiles({
       name: filename,
       mimeType,

--- a/apps/e2e/tests/utils/test-base.ts
+++ b/apps/e2e/tests/utils/test-base.ts
@@ -6,6 +6,7 @@ import { ProfilePage } from "../poms/ProfilePage";
 import { RegisterPage } from "../poms/RegisterPage";
 import { DashboardPage } from "../poms/DashboardPage";
 import { DoctorProfilePage } from "../poms/DoctorProfilePage";
+import { PatientsPage } from "../poms/PatientsPage";
 import { config } from "./config";
 
 export class CleanupHelper {
@@ -71,6 +72,7 @@ export const test = base.extend<{
   registerPage: RegisterPage;
   dashboardPage: DashboardPage;
   doctorProfilePage: DoctorProfilePage;
+  patientsPage: PatientsPage;
 }>({
   cleanup: async ({ request }, use) => {
     const helper = new CleanupHelper();
@@ -98,6 +100,9 @@ export const test = base.extend<{
   },
   doctorProfilePage: async ({ page }, use) => {
     await use(new DoctorProfilePage(page));
+  },
+  patientsPage: async ({ page }, use) => {
+    await use(new PatientsPage(page));
   },
 });
 

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -7,6 +7,7 @@ import { ProfilePage } from "@/pages/profile";
 import { DepartmentsPage } from "@/pages/departments";
 import { DoctorsPage } from "@/pages/doctors";
 import { DoctorProfilePage } from "@/pages/doctor-profile";
+import { PatientsPage } from "@/pages/patients";
 import { ProtectedRoute } from "@/components/auth/protected-route";
 
 export function App() {
@@ -22,6 +23,7 @@ export function App() {
           <Route path="/departments" element={<DepartmentsPage />} />
           <Route path="/doctors" element={<DoctorsPage />} />
           <Route path="/doctors/:id" element={<DoctorProfilePage />} />
+          <Route path="/patients" element={<PatientsPage />} />
           {/* Additional routes will be added per task */}
         </Route>
       </Route>

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -18,20 +18,26 @@ import { authApi } from "@/lib/api-client";
 import { useNavigate } from "react-router";
 
 const navItems = [
-  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { to: "/appointments", label: "Appointments", icon: Calendar },
-  { to: "/doctors", label: "Doctors", icon: Stethoscope },
-  { to: "/patients", label: "Patients", icon: Users },
-  { to: "/medical-records", label: "Medical Records", icon: FileText },
-  { to: "/invoices", label: "Invoices", icon: Receipt },
-  { to: "/notifications", label: "Notifications", icon: Bell },
-  { to: "/profile", label: "Profile", icon: User },
-  { to: "/settings", label: "Settings", icon: Settings },
+  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard, roles: null },
+  { to: "/appointments", label: "Appointments", icon: Calendar, roles: null },
+  { to: "/doctors", label: "Doctors", icon: Stethoscope, roles: null },
+  { to: "/patients", label: "Patients", icon: Users, roles: ["admin"] },
+  {
+    to: "/medical-records",
+    label: "Medical Records",
+    icon: FileText,
+    roles: null,
+  },
+  { to: "/invoices", label: "Invoices", icon: Receipt, roles: null },
+  { to: "/notifications", label: "Notifications", icon: Bell, roles: null },
+  { to: "/profile", label: "Profile", icon: User, roles: null },
+  { to: "/settings", label: "Settings", icon: Settings, roles: null },
 ];
 
 export function Sidebar() {
   const navigate = useNavigate();
   const clearAuth = useAuthStore((s) => s.clearAuth);
+  const user = useAuthStore((s) => s.user);
 
   const handleLogout = async () => {
     try {
@@ -56,27 +62,34 @@ export function Sidebar() {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto px-3 py-4" data-testid="sidebar-nav">
+      <nav
+        className="flex-1 overflow-y-auto px-3 py-4"
+        data-testid="sidebar-nav"
+      >
         <ul className="space-y-1">
-          {navItems.map(({ to, label, icon: Icon }) => (
-            <li key={to}>
-              <NavLink
-                to={to}
-                data-testid={`nav-${label.toLowerCase().replace(/\s+/g, "-")}`}
-                className={({ isActive }) =>
-                  cn(
-                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                    isActive
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                  )
-                }
-              >
-                <Icon className="h-4 w-4 shrink-0" />
-                {label}
-              </NavLink>
-            </li>
-          ))}
+          {navItems
+            .filter(
+              ({ roles }) => !roles || (user?.role && roles.includes(user.role))
+            )
+            .map(({ to, label, icon: Icon }) => (
+              <li key={to}>
+                <NavLink
+                  to={to}
+                  data-testid={`nav-${label.toLowerCase().replace(/\s+/g, "-")}`}
+                  className={({ isActive }) =>
+                    cn(
+                      "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                      isActive
+                        ? "bg-primary text-primary-foreground"
+                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                    )
+                  }
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  {label}
+                </NavLink>
+              </li>
+            ))}
         </ul>
       </nav>
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -7,6 +7,7 @@ import type {
   Department,
   Doctor,
   DoctorSchedule,
+  Patient,
 } from "@caresync/shared";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -234,6 +235,46 @@ export const doctorsApi = {
 
   deleteDoctor: async (id: string): Promise<void> => {
     await apiClient.delete(`/api/v1/doctors/${id}`);
+  },
+};
+
+interface UpsertPatientInput {
+  dateOfBirth?: string | null;
+  gender?: string | null;
+  bloodType?: string | null;
+  allergies?: string | null;
+  emergencyContactName?: string | null;
+  emergencyContactPhone?: string | null;
+}
+
+interface ListPatientsParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  gender?: string;
+  bloodType?: string;
+}
+
+export const patientsApi = {
+  getPatient: async (): Promise<Patient | null> => {
+    const res = await apiClient.get<Patient | null>("/api/v1/patients/me");
+    return res.data;
+  },
+
+  upsertPatient: async (data: UpsertPatientInput): Promise<Patient> => {
+    const res = await apiClient.put<Patient>("/api/v1/patients/me", data);
+    return res.data;
+  },
+
+  listPatients: async (
+    params?: ListPatientsParams
+  ): Promise<
+    PaginatedResponse<
+      Patient & { user: Pick<User, "id" | "email" | "firstName" | "lastName"> }
+    >
+  > => {
+    const res = await apiClient.get("/api/v1/patients", { params });
+    return res.data;
   },
 };
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -268,12 +268,11 @@ export const patientsApi = {
 
   listPatients: async (
     params?: ListPatientsParams
-  ): Promise<
-    PaginatedResponse<
-      Patient & { user: Pick<User, "id" | "email" | "firstName" | "lastName"> }
-    >
-  > => {
-    const res = await apiClient.get("/api/v1/patients", { params });
+  ): Promise<PaginatedResponse<Patient>> => {
+    const res = await apiClient.get<PaginatedResponse<Patient>>(
+      "/api/v1/patients",
+      { params }
+    );
     return res.data;
   },
 };

--- a/apps/web/src/pages/patients.test.tsx
+++ b/apps/web/src/pages/patients.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { PatientsPage } from "./patients";
+import { useAuthStore } from "@/stores/auth-store";
+import type { User, Patient } from "@caresync/shared";
+
+vi.mock("@/lib/api-client", () => ({
+  patientsApi: {
+    listPatients: vi.fn(),
+  },
+  authApi: {
+    login: vi.fn(),
+  },
+}));
+
+import { patientsApi } from "@/lib/api-client";
+
+const mockAdmin: User = {
+  id: "admin-uuid-1",
+  email: "admin@caresync.com",
+  role: "admin",
+  firstName: "Admin",
+  lastName: "User",
+  phone: null,
+  avatarUrl: null,
+  isActive: true,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const baseUser: User = {
+  id: "user-uuid-1",
+  email: "john@example.com",
+  role: "patient",
+  firstName: "John",
+  lastName: "Doe",
+  phone: null,
+  avatarUrl: null,
+  isActive: true,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const mockPatients: Patient[] = [
+  {
+    id: "patient-uuid-1",
+    userId: "user-uuid-1",
+    dateOfBirth: "1990-05-15",
+    gender: "male",
+    bloodType: "A+",
+    allergies: "penicillin",
+    emergencyContactName: "Jane Doe",
+    emergencyContactPhone: "+1234567890",
+    user: baseUser,
+  },
+  {
+    id: "patient-uuid-2",
+    userId: "user-uuid-2",
+    dateOfBirth: "1985-03-20",
+    gender: "female",
+    bloodType: "B-",
+    allergies: null,
+    emergencyContactName: null,
+    emergencyContactPhone: null,
+    user: {
+      ...baseUser,
+      id: "user-uuid-2",
+      email: "jane@example.com",
+      firstName: "Jane",
+      lastName: "Smith",
+    },
+  },
+];
+
+const mockPaginatedResponse = {
+  data: mockPatients,
+  total: 2,
+  page: 1,
+  limit: 20,
+  totalPages: 1,
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/patients"]}>
+      <Routes>
+        <Route path="/patients" element={<PatientsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("PatientsPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: mockAdmin,
+      accessToken: "tok-admin",
+      isLoading: false,
+    });
+    vi.resetAllMocks();
+  });
+
+  it("renders the page heading", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+    expect(await screen.findByTestId("patients-page")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /patients/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a table with patient rows", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    expect(
+      await screen.findByTestId("patient-row-patient-uuid-1")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("patient-row-patient-uuid-2")
+    ).toBeInTheDocument();
+  });
+
+  it("displays patient name, email, DOB, gender and blood type", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    const row = await screen.findByTestId("patient-row-patient-uuid-1");
+    expect(within(row).getByText("John Doe")).toBeInTheDocument();
+    expect(within(row).getByText("john@example.com")).toBeInTheDocument();
+    expect(within(row).getByText("1990-05-15")).toBeInTheDocument();
+    expect(within(row).getByText("male")).toBeInTheDocument();
+    expect(within(row).getByText("A+")).toBeInTheDocument();
+  });
+
+  it("renders the search input", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    await screen.findByTestId("patients-page");
+    expect(screen.getByTestId("search-input")).toBeInTheDocument();
+  });
+
+  it("renders gender and blood type filter dropdowns", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    await screen.findByTestId("patients-page");
+    expect(screen.getByTestId("gender-filter")).toBeInTheDocument();
+    expect(screen.getByTestId("blood-type-filter")).toBeInTheDocument();
+  });
+
+  it("calls listPatients with search param when user types", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    await screen.findByTestId("search-input");
+    await userEvent.type(screen.getByTestId("search-input"), "john");
+
+    await waitFor(() => {
+      expect(patientsApi.listPatients).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "john" })
+      );
+    });
+  });
+
+  it("calls listPatients with gender param when filter changes", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    await screen.findByTestId("gender-filter");
+    await userEvent.selectOptions(screen.getByTestId("gender-filter"), "male");
+
+    await waitFor(() => {
+      expect(patientsApi.listPatients).toHaveBeenCalledWith(
+        expect.objectContaining({ gender: "male" })
+      );
+    });
+  });
+
+  it("calls listPatients with bloodType param when filter changes", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    await screen.findByTestId("blood-type-filter");
+    await userEvent.selectOptions(
+      screen.getByTestId("blood-type-filter"),
+      "A+"
+    );
+
+    await waitFor(() => {
+      expect(patientsApi.listPatients).toHaveBeenCalledWith(
+        expect.objectContaining({ bloodType: "A+" })
+      );
+    });
+  });
+
+  it("shows an empty state when no patients are returned", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+    });
+    renderPage();
+
+    expect(await screen.findByTestId("patients-empty")).toBeInTheDocument();
+  });
+
+  it("shows pagination info", async () => {
+    vi.mocked(patientsApi.listPatients).mockResolvedValue(
+      mockPaginatedResponse
+    );
+    renderPage();
+
+    await screen.findByTestId("patient-row-patient-uuid-1");
+    expect(screen.getByTestId("pagination-info")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/patients.tsx
+++ b/apps/web/src/pages/patients.tsx
@@ -1,0 +1,205 @@
+import { useState, useEffect, useCallback } from "react";
+import { patientsApi } from "@/lib/api-client";
+import { BLOOD_TYPES, GENDERS } from "@caresync/shared";
+import type { Patient } from "@caresync/shared";
+
+export function PatientsPage() {
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [search, setSearch] = useState("");
+  const [gender, setGender] = useState("");
+  const [bloodType, setBloodType] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const LIMIT = 20;
+
+  const fetchPatients = useCallback(
+    async (params: {
+      page: number;
+      search: string;
+      gender: string;
+      bloodType: string;
+    }) => {
+      setLoading(true);
+      try {
+        const res = await patientsApi.listPatients({
+          page: params.page,
+          limit: LIMIT,
+          search: params.search || undefined,
+          gender: params.gender || undefined,
+          bloodType: params.bloodType || undefined,
+        });
+        setPatients(res.data);
+        setTotal(res.total);
+        setTotalPages(res.totalPages);
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    fetchPatients({ page, search, gender, bloodType });
+  }, [fetchPatients, page, search, gender, bloodType]);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+    setPage(1);
+  };
+
+  const handleGenderChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setGender(e.target.value);
+    setPage(1);
+  };
+
+  const handleBloodTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setBloodType(e.target.value);
+    setPage(1);
+  };
+
+  return (
+    <div data-testid="patients-page">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-foreground">Patients</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage patient profiles and medical information
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex flex-wrap gap-3">
+        <input
+          type="text"
+          data-testid="search-input"
+          placeholder="Search by name or email…"
+          value={search}
+          onChange={handleSearchChange}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring w-64"
+        />
+
+        <select
+          data-testid="gender-filter"
+          value={gender}
+          onChange={handleGenderChange}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">All genders</option>
+          {GENDERS.map((g) => (
+            <option key={g} value={g}>
+              {g.charAt(0).toUpperCase() + g.slice(1)}
+            </option>
+          ))}
+        </select>
+
+        <select
+          data-testid="blood-type-filter"
+          value={bloodType}
+          onChange={handleBloodTypeChange}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">All blood types</option>
+          {BLOOD_TYPES.map((bt) => (
+            <option key={bt} value={bt}>
+              {bt}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-lg border border-border bg-card">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Name
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Email
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Date of Birth
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Gender
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Blood Type
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {!loading && patients.length === 0 && (
+              <tr>
+                <td
+                  colSpan={5}
+                  data-testid="patients-empty"
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
+                  No patients found.
+                </td>
+              </tr>
+            )}
+            {patients.map((patient) => (
+              <tr
+                key={patient.id}
+                data-testid={`patient-row-${patient.id}`}
+                className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors"
+              >
+                <td className="px-4 py-3 font-medium text-foreground">
+                  {patient.user?.firstName} {patient.user?.lastName}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {patient.user?.email}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {patient.dateOfBirth ?? "—"}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {patient.gender ?? "—"}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {patient.bloodType ?? "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div
+        data-testid="pagination-info"
+        className="mt-4 flex items-center justify-between text-sm text-muted-foreground"
+      >
+        <span>
+          {total === 0
+            ? "No patients"
+            : `Showing ${(page - 1) * LIMIT + 1}–${Math.min(page * LIMIT, total)} of ${total}`}
+        </span>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            className="rounded-md border border-input px-3 py-1 disabled:opacity-40 hover:bg-accent"
+          >
+            Previous
+          </button>
+          <span className="px-2 py-1">
+            {page} / {totalPages || 1}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page >= totalPages}
+            className="rounded-md border border-input px-3 py-1 disabled:opacity-40 hover:bg-accent"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/profile.test.tsx
+++ b/apps/web/src/pages/profile.test.tsx
@@ -4,19 +4,23 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { ProfilePage } from "./profile";
 import { useAuthStore } from "@/stores/auth-store";
-import type { User } from "@caresync/shared";
+import type { User, Patient } from "@caresync/shared";
 
 vi.mock("@/lib/api-client", () => ({
   usersApi: {
     updateProfile: vi.fn(),
     updateAvatar: vi.fn(),
   },
+  patientsApi: {
+    getPatient: vi.fn(),
+    upsertPatient: vi.fn(),
+  },
   authApi: {
     login: vi.fn(),
   },
 }));
 
-import { usersApi } from "@/lib/api-client";
+import { usersApi, patientsApi } from "@/lib/api-client";
 
 const mockUser: User = {
   id: "user-uuid-123",
@@ -44,14 +48,21 @@ function renderProfile() {
 
 describe("ProfilePage", () => {
   beforeEach(() => {
-    useAuthStore.setState({ user: mockUser, accessToken: "tok-123", isLoading: false });
+    useAuthStore.setState({
+      user: mockUser,
+      accessToken: "tok-123",
+      isLoading: false,
+    });
     vi.resetAllMocks();
+    vi.mocked(patientsApi.getPatient).mockResolvedValue(null);
   });
 
   it("renders the page with a heading", () => {
     renderProfile();
     expect(screen.getByTestId("profile-page")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^profile$/i, level: 1 })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /^profile$/i, level: 1 })
+    ).toBeInTheDocument();
   });
 
   it("pre-fills the form with the current user's data", () => {
@@ -103,7 +114,10 @@ describe("ProfilePage", () => {
   });
 
   it("shows a success message after saving", async () => {
-    vi.mocked(usersApi.updateProfile).mockResolvedValue({ ...mockUser, firstName: "Jane" });
+    vi.mocked(usersApi.updateProfile).mockResolvedValue({
+      ...mockUser,
+      firstName: "Jane",
+    });
     renderProfile();
 
     await userEvent.click(screen.getByTestId("save-profile-button"));
@@ -138,5 +152,111 @@ describe("ProfilePage", () => {
   it("renders the avatar upload section", () => {
     renderProfile();
     expect(screen.getByTestId("avatar-upload-input")).toBeInTheDocument();
+  });
+
+  it("does not render the Medical Information section for non-patient roles", () => {
+    useAuthStore.setState({
+      user: { ...mockUser, role: "admin" },
+      accessToken: "tok-123",
+      isLoading: false,
+    });
+    renderProfile();
+    expect(
+      screen.queryByTestId("medical-info-section")
+    ).not.toBeInTheDocument();
+  });
+});
+
+const mockPatient: Patient = {
+  id: "patient-uuid-123",
+  userId: "user-uuid-123",
+  dateOfBirth: "1990-05-15",
+  gender: "male",
+  bloodType: "A+",
+  allergies: "penicillin",
+  emergencyContactName: "Jane Doe",
+  emergencyContactPhone: "+1234567890",
+};
+
+describe("ProfilePage — Medical Information section (patient role)", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: mockUser,
+      accessToken: "tok-123",
+      isLoading: false,
+    });
+    vi.resetAllMocks();
+  });
+
+  it("renders the Medical Information section for patients", async () => {
+    vi.mocked(patientsApi.getPatient).mockResolvedValue(null);
+    renderProfile();
+    expect(
+      await screen.findByTestId("medical-info-section")
+    ).toBeInTheDocument();
+  });
+
+  it("pre-fills medical fields from existing patient data", async () => {
+    vi.mocked(patientsApi.getPatient).mockResolvedValue(mockPatient);
+    renderProfile();
+
+    expect(await screen.findByTestId("dob-input")).toHaveValue("1990-05-15");
+    expect(screen.getByTestId("gender-select")).toHaveValue("male");
+    expect(screen.getByTestId("blood-type-select")).toHaveValue("A+");
+    expect(screen.getByTestId("allergies-input")).toHaveValue("penicillin");
+    expect(screen.getByTestId("emergency-contact-name-input")).toHaveValue(
+      "Jane Doe"
+    );
+    expect(screen.getByTestId("emergency-contact-phone-input")).toHaveValue(
+      "+1234567890"
+    );
+  });
+
+  it("shows empty fields when no patient row exists", async () => {
+    vi.mocked(patientsApi.getPatient).mockResolvedValue(null);
+    renderProfile();
+
+    expect(await screen.findByTestId("dob-input")).toHaveValue("");
+    expect(screen.getByTestId("gender-select")).toHaveValue("");
+    expect(screen.getByTestId("blood-type-select")).toHaveValue("");
+  });
+
+  it("calls patientsApi.upsertPatient on submit", async () => {
+    vi.mocked(patientsApi.getPatient).mockResolvedValue(mockPatient);
+    vi.mocked(patientsApi.upsertPatient).mockResolvedValue(mockPatient);
+    renderProfile();
+
+    await screen.findByTestId("medical-info-section");
+    await userEvent.click(screen.getByTestId("save-medical-button"));
+
+    await waitFor(() => {
+      expect(patientsApi.upsertPatient).toHaveBeenCalled();
+    });
+  });
+
+  it("shows success message after saving medical info", async () => {
+    vi.mocked(patientsApi.getPatient).mockResolvedValue(mockPatient);
+    vi.mocked(patientsApi.upsertPatient).mockResolvedValue(mockPatient);
+    renderProfile();
+
+    await screen.findByTestId("medical-info-section");
+    await userEvent.click(screen.getByTestId("save-medical-button"));
+
+    expect(await screen.findByTestId("medical-success")).toBeInTheDocument();
+  });
+
+  it("shows error message when medical save fails", async () => {
+    vi.mocked(patientsApi.getPatient).mockResolvedValue(null);
+    vi.mocked(patientsApi.upsertPatient).mockRejectedValue(
+      Object.assign(new Error("fail"), {
+        response: { data: { message: "Validation error" } },
+      })
+    );
+    renderProfile();
+
+    await screen.findByTestId("medical-info-section");
+    await userEvent.click(screen.getByTestId("save-medical-button"));
+
+    expect(await screen.findByTestId("medical-error")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -1,9 +1,10 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { usersApi } from "@/lib/api-client";
+import { usersApi, patientsApi } from "@/lib/api-client";
 import { useAuthStore } from "@/stores/auth-store";
+import { BLOOD_TYPES, GENDERS } from "@caresync/shared";
 
 const profileSchema = z.object({
   firstName: z.string().min(1, "First name is required"),
@@ -12,6 +13,207 @@ const profileSchema = z.object({
 });
 
 type ProfileInput = z.infer<typeof profileSchema>;
+
+// ─── Medical Information form (patient role only) ─────────────────────────────
+
+const medicalSchema = z.object({
+  dateOfBirth: z.string().optional(),
+  gender: z.string().optional(),
+  bloodType: z.string().optional(),
+  allergies: z.string().max(1000).optional(),
+  emergencyContactName: z.string().max(100).optional(),
+  emergencyContactPhone: z.string().optional(),
+});
+
+type MedicalInput = z.infer<typeof medicalSchema>;
+
+function MedicalInfoForm() {
+  const [success, setSuccess] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<MedicalInput>({ resolver: zodResolver(medicalSchema) });
+
+  useEffect(() => {
+    patientsApi.getPatient().then((patient) => {
+      if (patient) {
+        reset({
+          dateOfBirth: patient.dateOfBirth ?? "",
+          gender: patient.gender ?? "",
+          bloodType: patient.bloodType ?? "",
+          allergies: patient.allergies ?? "",
+          emergencyContactName: patient.emergencyContactName ?? "",
+          emergencyContactPhone: patient.emergencyContactPhone ?? "",
+        });
+      }
+    });
+  }, [reset]);
+
+  const onSubmit = async (data: MedicalInput) => {
+    setSuccess(false);
+    setServerError(null);
+    try {
+      await patientsApi.upsertPatient({
+        dateOfBirth: data.dateOfBirth || null,
+        gender: data.gender || null,
+        bloodType: data.bloodType || null,
+        allergies: data.allergies || null,
+        emergencyContactName: data.emergencyContactName || null,
+        emergencyContactPhone: data.emergencyContactPhone || null,
+      });
+      setSuccess(true);
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } })
+        ?.response?.data?.message;
+      setServerError(msg ?? "Something went wrong. Please try again.");
+    }
+  };
+
+  return (
+    <div
+      data-testid="medical-info-section"
+      className="rounded-lg border border-border bg-card p-6"
+    >
+      <h2 className="mb-4 text-lg font-semibold text-card-foreground">
+        Medical Information
+      </h2>
+
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+        {serverError && (
+          <p
+            role="alert"
+            data-testid="medical-error"
+            className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {serverError}
+          </p>
+        )}
+        {success && (
+          <p
+            data-testid="medical-success"
+            className="rounded-md bg-green-50 px-3 py-2 text-sm text-green-700"
+          >
+            Medical information updated successfully.
+          </p>
+        )}
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="dateOfBirth" className="text-sm font-medium">
+              Date of birth
+            </label>
+            <input
+              id="dateOfBirth"
+              type="date"
+              data-testid="dob-input"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              {...register("dateOfBirth")}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="gender" className="text-sm font-medium">
+              Gender
+            </label>
+            <select
+              id="gender"
+              data-testid="gender-select"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              {...register("gender")}
+            >
+              <option value="">Select gender</option>
+              {GENDERS.map((g) => (
+                <option key={g} value={g}>
+                  {g.charAt(0).toUpperCase() + g.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="bloodType" className="text-sm font-medium">
+            Blood type
+          </label>
+          <select
+            id="bloodType"
+            data-testid="blood-type-select"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            {...register("bloodType")}
+          >
+            <option value="">Select blood type</option>
+            {BLOOD_TYPES.map((bt) => (
+              <option key={bt} value={bt}>
+                {bt}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="allergies" className="text-sm font-medium">
+            Allergies
+          </label>
+          <textarea
+            id="allergies"
+            data-testid="allergies-input"
+            rows={3}
+            maxLength={1000}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            {...register("allergies")}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label
+              htmlFor="emergencyContactName"
+              className="text-sm font-medium"
+            >
+              Emergency contact name
+            </label>
+            <input
+              id="emergencyContactName"
+              type="text"
+              data-testid="emergency-contact-name-input"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              {...register("emergencyContactName")}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="emergencyContactPhone"
+              className="text-sm font-medium"
+            >
+              Emergency contact phone
+            </label>
+            <input
+              id="emergencyContactPhone"
+              type="tel"
+              data-testid="emergency-contact-phone-input"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              {...register("emergencyContactPhone")}
+            />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          data-testid="save-medical-button"
+          className="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isSubmitting ? "Saving…" : "Save medical info"}
+        </button>
+      </form>
+    </div>
+  );
+}
 
 export function ProfilePage() {
   const user = useAuthStore((s) => s.user);
@@ -49,8 +251,8 @@ export function ProfilePage() {
       }
       setSuccess(true);
     } catch (err: unknown) {
-      const msg =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+      const msg = (err as { response?: { data?: { message?: string } } })
+        ?.response?.data?.message;
       setServerError(msg ?? "Something went wrong. Please try again.");
     }
   };
@@ -67,8 +269,8 @@ export function ProfilePage() {
         setAuth(updated, accessToken);
       }
     } catch (err: unknown) {
-      const msg =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+      const msg = (err as { response?: { data?: { message?: string } } })
+        ?.response?.data?.message;
       setAvatarError(msg ?? "Failed to upload avatar.");
     }
   };
@@ -77,13 +279,17 @@ export function ProfilePage() {
     <div data-testid="profile-page">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-foreground">Profile</h1>
-        <p className="text-sm text-muted-foreground">Manage your account information</p>
+        <p className="text-sm text-muted-foreground">
+          Manage your account information
+        </p>
       </div>
 
       <div className="max-w-2xl space-y-8">
         {/* Avatar section */}
         <div className="rounded-lg border border-border bg-card p-6">
-          <h2 className="mb-4 text-lg font-semibold text-card-foreground">Profile Picture</h2>
+          <h2 className="mb-4 text-lg font-semibold text-card-foreground">
+            Profile Picture
+          </h2>
           <div className="flex items-center gap-4">
             <div className="flex h-20 w-20 items-center justify-center rounded-full bg-muted text-2xl font-bold text-muted-foreground overflow-hidden">
               {user?.avatarUrl ? (
@@ -95,7 +301,8 @@ export function ProfilePage() {
                 />
               ) : (
                 <span data-testid="avatar-initials">
-                  {user?.firstName?.[0]}{user?.lastName?.[0]}
+                  {user?.firstName?.[0]}
+                  {user?.lastName?.[0]}
                 </span>
               )}
             </div>
@@ -117,7 +324,10 @@ export function ProfilePage() {
                 Change avatar
               </button>
               {avatarError && (
-                <p className="mt-1 text-xs text-destructive" data-testid="avatar-error">
+                <p
+                  className="mt-1 text-xs text-destructive"
+                  data-testid="avatar-error"
+                >
                   {avatarError}
                 </p>
               )}
@@ -127,7 +337,9 @@ export function ProfilePage() {
 
         {/* Profile form */}
         <div className="rounded-lg border border-border bg-card p-6">
-          <h2 className="mb-4 text-lg font-semibold text-card-foreground">Personal Information</h2>
+          <h2 className="mb-4 text-lg font-semibold text-card-foreground">
+            Personal Information
+          </h2>
 
           <div className="mb-4">
             <p className="text-sm font-medium text-muted-foreground">Email</p>
@@ -136,10 +348,16 @@ export function ProfilePage() {
 
           <div className="mb-4">
             <p className="text-sm font-medium text-muted-foreground">Role</p>
-            <p className="mt-1 text-sm capitalize text-foreground">{user?.role}</p>
+            <p className="mt-1 text-sm capitalize text-foreground">
+              {user?.role}
+            </p>
           </div>
 
-          <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            noValidate
+            className="space-y-4"
+          >
             {serverError && (
               <p
                 role="alert"
@@ -171,7 +389,10 @@ export function ProfilePage() {
                   {...register("firstName")}
                 />
                 {errors.firstName && (
-                  <p className="text-xs text-destructive" data-testid="first-name-error">
+                  <p
+                    className="text-xs text-destructive"
+                    data-testid="first-name-error"
+                  >
                     {errors.firstName.message}
                   </p>
                 )}
@@ -189,7 +410,10 @@ export function ProfilePage() {
                   {...register("lastName")}
                 />
                 {errors.lastName && (
-                  <p className="text-xs text-destructive" data-testid="last-name-error">
+                  <p
+                    className="text-xs text-destructive"
+                    data-testid="last-name-error"
+                  >
                     {errors.lastName.message}
                   </p>
                 )}
@@ -219,6 +443,9 @@ export function ProfilePage() {
             </button>
           </form>
         </div>
+
+        {/* Medical Information — patient role only */}
+        {user?.role === "patient" && <MedicalInfoForm />}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #14

## Summary

- **API**: `GET /patients/me` returns patient record (auto-created on registration with null fields); `PUT /patients/me` upserts medical data with full validation (DOB must be past, blood type enum-constrained, allergies max 1000 chars); `GET /patients` admin list with search, gender, blood type filters and pagination
- **Frontend**: Medical Information card on `/profile` (patient role only) with DOB, gender, blood type, allergies, emergency contact fields; new `/patients` admin page with compact table, search, filters, and pagination; sidebar link visible to admins only
- **E2E tests**: Full Playwright coverage — PP-1–6 (patient profile UI), PP-A1–A4 (API), PAT-1–8 (patients list UI + access control), PAT-A1–A3 (admin API); also fixes parallel flakiness by capping workers at 2 and replacing `waitForTimeout` with `waitForResponse`

## Test plan

- [ ] `GET /patients/me` returns empty record (all null fields) for a new patient
- [ ] `PUT /patients/me` upserts medical fields; rejects future DOB, invalid blood type, allergies > 1000 chars
- [ ] `GET /patients` returns paginated list for admin; filters by gender and blood type; 403 for non-admins
- [ ] Medical Information section visible on `/profile` for patients, hidden for admin
- [ ] `/patients` page loads with search, gender filter, blood type filter, and pagination
- [ ] Sidebar `/patients` link visible to admin only
- [ ] All 21 new e2e tests pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)