### PR TITLE
feat(appointments): appointment management & status lifecycle (#16)

### DIFF
--- a/apps/api/src/routes/appointments.test.ts
+++ b/apps/api/src/routes/appointments.test.ts
@@ -551,3 +551,187 @@ describe("GET /appointments/:id", () => {
     expect(res.status).toBe(200);
   });
 });
+
+// ─── PATCH /appointments/:id/status ──────────────────────────────────────────
+
+function makeUpdateChain(result: unknown[]) {
+  const returning = vi.fn().mockResolvedValue(result);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  return { set };
+}
+
+describe("PATCH /appointments/:id/status", () => {
+  const STATUS_URL = `${APPOINTMENTS_URL}/${APPT_ID}/status`;
+  const jsonH = { "Content-Type": "application/json" };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: jsonH,
+      body: JSON.stringify({ status: "confirmed" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when appointment not found", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinChain([]) as any);
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(adminToken) },
+      body: JSON.stringify({ status: "confirmed" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when patient tries to update another patient's appointment", async () => {
+    const foreign = {
+      ...mockDetailRow,
+      patient: { ...mockDetailRow.patient, userId: "different-user-id" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinChain([foreign]) as any);
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(patientToken) },
+      body: JSON.stringify({ status: "cancelled" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when doctor tries to update another doctor's appointment", async () => {
+    const foreign = {
+      ...mockDetailRow,
+      doctor: { ...mockDetailRow.doctor, userId: "different-doctor-id" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinChain([foreign]) as any);
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(doctorToken) },
+      body: JSON.stringify({ status: "confirmed" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 422 for an invalid status transition (pending → completed)", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([mockDetailRow]) as any
+    );
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(adminToken) },
+      body: JSON.stringify({ status: "completed" }),
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.message).toMatch(/invalid.*transition/i);
+  });
+
+  it("returns 403 when patient tries to confirm (only cancel allowed)", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([mockDetailRow]) as any
+    );
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(patientToken) },
+      body: JSON.stringify({ status: "confirmed" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when doctor tries to cancel (not allowed for doctor)", async () => {
+    const confirmedAppt = {
+      ...mockDetailRow,
+      appointment: { ...mockDetailRow.appointment, status: "confirmed" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([confirmedAppt]) as any
+    );
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(doctorToken) },
+      body: JSON.stringify({ status: "cancelled" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 when patient cancels a pending appointment", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([mockDetailRow]) as any // status: pending
+    );
+    const updatedAppt = {
+      ...mockDetailRow,
+      appointment: { ...mockDetailRow.appointment, status: "cancelled" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([updatedAppt]) as any // re-fetch after update
+    );
+    vi.mocked(db.update).mockReturnValueOnce(
+      makeUpdateChain([{ id: APPT_ID, status: "cancelled" }]) as any
+    );
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(patientToken) },
+      body: JSON.stringify({ status: "cancelled" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.appointment.status).toBe("cancelled");
+  });
+
+  it("returns 200 when doctor confirms a pending appointment", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([mockDetailRow]) as any // status: pending
+    );
+    const updatedAppt = {
+      ...mockDetailRow,
+      appointment: { ...mockDetailRow.appointment, status: "confirmed" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([updatedAppt]) as any
+    );
+    vi.mocked(db.update).mockReturnValueOnce(
+      makeUpdateChain([{ id: APPT_ID, status: "confirmed" }]) as any
+    );
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(doctorToken) },
+      body: JSON.stringify({ status: "confirmed" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.appointment.status).toBe("confirmed");
+  });
+
+  it("returns 200 when admin sets any valid transition", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([mockDetailRow]) as any // status: pending
+    );
+    const updatedAppt = {
+      ...mockDetailRow,
+      appointment: { ...mockDetailRow.appointment, status: "confirmed" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([updatedAppt]) as any
+    );
+    vi.mocked(db.update).mockReturnValueOnce(
+      makeUpdateChain([{ id: APPT_ID, status: "confirmed" }]) as any
+    );
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(adminToken) },
+      body: JSON.stringify({ status: "confirmed" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 for an unrecognised status value", async () => {
+    const res = await app.request(STATUS_URL, {
+      method: "PATCH",
+      headers: { ...jsonH, ...bearer(adminToken) },
+      body: JSON.stringify({ status: "invalid-status" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/appointments.test.ts
+++ b/apps/api/src/routes/appointments.test.ts
@@ -244,8 +244,10 @@ describe("POST /appointments", () => {
   });
 
   it("returns 400 for an appointmentDate more than 60 days out", async () => {
+    // Use +90 UTC days — always past the 60-day Jakarta window regardless of
+    // UTC/Jakarta day boundary (avoids off-by-one when CI runs after 17:00 UTC).
     const farFuture = new Date();
-    farFuture.setDate(farFuture.getDate() + 61);
+    farFuture.setDate(farFuture.getDate() + 90);
     const farFutureStr = farFuture.toISOString().substring(0, 10);
 
     const res = await app.request(APPOINTMENTS_URL, {

--- a/apps/api/src/routes/appointments.test.ts
+++ b/apps/api/src/routes/appointments.test.ts
@@ -101,6 +101,85 @@ const validBody = {
   reason: "Annual checkup",
 };
 
+// ─── Join-chain mock for complex SELECT queries ───────────────────────────────
+
+function makeJoinChain(result: unknown[]) {
+  const terminalChain: any = {
+    offset: vi.fn().mockResolvedValue(result),
+    then: (onFulfilled?: any, onRejected?: any) =>
+      Promise.resolve(result).then(onFulfilled, onRejected),
+    catch: (onRejected?: any) => Promise.resolve(result).catch(onRejected),
+    finally: (onFinally?: any) => Promise.resolve(result).finally(onFinally),
+  };
+  const chain: any = {};
+  for (const m of ["from", "innerJoin", "leftJoin", "where", "orderBy"]) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain.limit = vi.fn().mockReturnValue(terminalChain);
+  return chain;
+}
+
+const USER_DOCTOR_ID = "a1b2c3d4-0000-4000-8000-000000000006";
+
+const mockListRow = {
+  appointment: { ...mockAppointment },
+  patientFirstName: "John",
+  patientLastName: "Doe",
+  patientUserId: USER_PATIENT_ID,
+  doctorFirstName: "Jane",
+  doctorLastName: "Smith",
+  doctorUserId: USER_DOCTOR_ID,
+  doctorSpecialization: "Cardiology",
+};
+
+const mockDetailRow = {
+  appointment: { ...mockAppointment },
+  patient: {
+    id: PATIENT_ID,
+    userId: USER_PATIENT_ID,
+    dateOfBirth: null,
+    gender: null,
+    bloodType: null,
+    allergies: null,
+    emergencyContactName: null,
+    emergencyContactPhone: null,
+  },
+  patientUser: {
+    id: USER_PATIENT_ID,
+    email: "patient@test.com",
+    role: "patient",
+    firstName: "John",
+    lastName: "Doe",
+    phone: null,
+    avatarUrl: null,
+    isActive: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    passwordHash: "hashed",
+  },
+  doctor: {
+    id: DOCTOR_ID,
+    userId: USER_DOCTOR_ID,
+    departmentId: "a1b2c3d4-0000-4000-8000-000000000020",
+    specialization: "Cardiology",
+    bio: null,
+    licenseNumber: "LIC-001",
+  },
+  doctorUser: {
+    id: USER_DOCTOR_ID,
+    email: "doctor@test.com",
+    role: "doctor",
+    firstName: "Jane",
+    lastName: "Smith",
+    phone: null,
+    avatarUrl: null,
+    isActive: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    passwordHash: "hashed",
+  },
+};
+
 // ─── POST /appointments ───────────────────────────────────────────────────────
 
 describe("POST /appointments", () => {
@@ -291,5 +370,184 @@ describe("POST /appointments", () => {
       body: JSON.stringify(bodyNoReason),
     });
     expect(res.status).toBe(201);
+  });
+});
+
+// ─── GET /appointments ────────────────────────────────────────────────────────
+
+describe("GET /appointments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await app.request(APPOINTMENTS_URL, { method: "GET" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with paginated list for patient role", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeJoinChain([{ count: 1 }]) as any) // count
+      .mockReturnValueOnce(makeJoinChain([mockListRow]) as any); // data
+    const res = await app.request(APPOINTMENTS_URL, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.total).toBe(1);
+    expect(body.page).toBe(1);
+    expect(body.totalPages).toBe(1);
+    expect(body.data[0].patientName).toBe("John Doe");
+    expect(body.data[0].doctorName).toBe("Jane Smith");
+    expect(body.data[0].doctorSpecialization).toBe("Cardiology");
+  });
+
+  it("returns 200 with paginated list for doctor role", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeJoinChain([{ count: 1 }]) as any)
+      .mockReturnValueOnce(makeJoinChain([mockListRow]) as any);
+    const res = await app.request(APPOINTMENTS_URL, {
+      method: "GET",
+      headers: bearer(doctorToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("returns 200 with paginated list for admin role", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeJoinChain([{ count: 1 }]) as any)
+      .mockReturnValueOnce(makeJoinChain([mockListRow]) as any);
+    const res = await app.request(APPOINTMENTS_URL, {
+      method: "GET",
+      headers: bearer(adminToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("returns empty data array when no appointments exist", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeJoinChain([{ count: 0 }]) as any)
+      .mockReturnValueOnce(makeJoinChain([]) as any);
+    const res = await app.request(`${APPOINTMENTS_URL}?status=confirmed`, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(0);
+    expect(body.total).toBe(0);
+  });
+
+  it("respects custom page and limit params and computes totalPages", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeJoinChain([{ count: 25 }]) as any)
+      .mockReturnValueOnce(makeJoinChain([mockListRow]) as any);
+    const res = await app.request(`${APPOINTMENTS_URL}?page=2&limit=10`, {
+      method: "GET",
+      headers: bearer(adminToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.page).toBe(2);
+    expect(body.limit).toBe(10);
+    expect(body.totalPages).toBe(3);
+  });
+});
+
+// ─── GET /appointments/:id ────────────────────────────────────────────────────
+
+describe("GET /appointments/:id", () => {
+  const DETAIL_URL = `${APPOINTMENTS_URL}/${APPT_ID}`;
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await app.request(DETAIL_URL, { method: "GET" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when appointment does not exist", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinChain([]) as any);
+    const res = await app.request(DETAIL_URL, {
+      method: "GET",
+      headers: bearer(adminToken),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when patient accesses another patient's appointment", async () => {
+    const foreign = {
+      ...mockDetailRow,
+      patient: { ...mockDetailRow.patient, userId: "different-user-id" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinChain([foreign]) as any);
+    const res = await app.request(DETAIL_URL, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when doctor accesses another doctor's appointment", async () => {
+    const foreign = {
+      ...mockDetailRow,
+      doctor: { ...mockDetailRow.doctor, userId: "different-doctor-id" },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinChain([foreign]) as any);
+    const res = await app.request(DETAIL_URL, {
+      method: "GET",
+      headers: bearer(doctorToken),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with nested patient and doctor for own appointment (patient)", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([mockDetailRow]) as any
+    );
+    const res = await app.request(DETAIL_URL, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(APPT_ID);
+    expect(body.patient).toBeDefined();
+    expect(body.doctor).toBeDefined();
+    expect(body.patient.user).toBeDefined();
+    expect(body.doctor.user).toBeDefined();
+    expect(body.patient.user.passwordHash).toBeUndefined();
+    expect(body.doctor.user.passwordHash).toBeUndefined();
+  });
+
+  it("returns 200 for doctor accessing their own appointment", async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      makeJoinChain([mockDetailRow]) as any
+    );
+    const res = await app.request(DETAIL_URL, {
+      method: "GET",
+      headers: bearer(doctorToken),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 for admin accessing any appointment", async () => {
+    const anyAppt = {
+      ...mockDetailRow,
+      patient: {
+        ...mockDetailRow.patient,
+        userId: "completely-different-user",
+      },
+    };
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinChain([anyAppt]) as any);
+    const res = await app.request(DETAIL_URL, {
+      method: "GET",
+      headers: bearer(adminToken),
+    });
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/api/src/routes/appointments.ts
+++ b/apps/api/src/routes/appointments.ts
@@ -293,6 +293,179 @@ appointmentsRoute.openapi(getAppointmentRoute, async (c) => {
   );
 });
 
+// ─── PATCH /appointments/:id/status ──────────────────────────────────────────
+
+// Valid next statuses for each current status
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  pending: ["confirmed", "cancelled"],
+  confirmed: ["in-progress", "cancelled"],
+  "in-progress": ["completed", "cancelled"],
+  completed: [],
+  cancelled: [],
+  "no-show": [],
+};
+
+// What statuses each role may set (regardless of current status)
+const ROLE_ALLOWED_TRANSITIONS: Record<string, string[]> = {
+  patient: ["cancelled"],
+  doctor: ["confirmed", "in-progress", "completed"],
+  admin: ["confirmed", "in-progress", "completed", "cancelled", "no-show"],
+};
+
+const patchStatusBody = z.object({ status: z.enum(APPOINTMENT_STATUSES) });
+
+const statusUpdateResponse = z.object({
+  appointment: appointmentDetailResponse,
+});
+
+const patchStatusRoute = createRoute({
+  method: "patch",
+  path: "/appointments/{id}/status",
+  tags: ["Appointments"],
+  summary: "Update appointment status",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth] as const,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { "application/json": { schema: patchStatusBody } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: "Status updated",
+      content: { "application/json": { schema: statusUpdateResponse } },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    422: {
+      description: "Invalid status transition",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+appointmentsRoute.openapi(patchStatusRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const { status: newStatus } = c.req.valid("json");
+  const userId = c.get("userId");
+  const userRole = c.get("userRole");
+
+  const patientUser = alias(users, "patient_user");
+  const doctorUser = alias(users, "doctor_user");
+
+  // 1. Fetch appointment with ownership info
+  const rows = await db
+    .select({
+      appointment: appointments,
+      patient: patients,
+      patientUser: patientUser,
+      doctor: doctors,
+      doctorUser: doctorUser,
+    })
+    .from(appointments)
+    .innerJoin(patients, eq(appointments.patientId, patients.id))
+    .innerJoin(patientUser, eq(patients.userId, patientUser.id))
+    .innerJoin(doctors, eq(appointments.doctorId, doctors.id))
+    .innerJoin(doctorUser, eq(doctors.userId, doctorUser.id))
+    .where(eq(appointments.id, id))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return c.json({ message: "Appointment not found" }, 404);
+
+  // 2. Ownership check
+  if (userRole === "patient" && row.patient.userId !== userId) {
+    return c.json({ message: "Forbidden" }, 403);
+  }
+  if (userRole === "doctor" && row.doctor.userId !== userId) {
+    return c.json({ message: "Forbidden" }, 403);
+  }
+
+  // 3. Role-based allowed transitions
+  const roleAllowed = ROLE_ALLOWED_TRANSITIONS[userRole] ?? [];
+  if (!roleAllowed.includes(newStatus)) {
+    return c.json({ message: "Forbidden" }, 403);
+  }
+
+  // 4. Validate transition in matrix
+  const currentStatus = row.appointment.status;
+  const validNext = VALID_TRANSITIONS[currentStatus] ?? [];
+  if (!validNext.includes(newStatus)) {
+    return c.json(
+      { message: `Invalid status transition: ${currentStatus} → ${newStatus}` },
+      422
+    );
+  }
+
+  // 5. Apply the update
+  await db
+    .update(appointments)
+    .set({ status: newStatus, updatedAt: new Date() })
+    .where(eq(appointments.id, id))
+    .returning();
+
+  // 6. Re-fetch full detail
+  const updatedRows = await db
+    .select({
+      appointment: appointments,
+      patient: patients,
+      patientUser: patientUser,
+      doctor: doctors,
+      doctorUser: doctorUser,
+    })
+    .from(appointments)
+    .innerJoin(patients, eq(appointments.patientId, patients.id))
+    .innerJoin(patientUser, eq(patients.userId, patientUser.id))
+    .innerJoin(doctors, eq(appointments.doctorId, doctors.id))
+    .innerJoin(doctorUser, eq(doctors.userId, doctorUser.id))
+    .where(eq(appointments.id, id))
+    .limit(1);
+
+  const updated = updatedRows[0]!;
+
+  const {
+    passwordHash: _ph1,
+    createdAt: _pc,
+    updatedAt: _pu,
+    ...patientUserSafe
+  } = updated.patientUser;
+  const {
+    passwordHash: _ph2,
+    createdAt: _dc,
+    updatedAt: _du,
+    ...doctorUserSafe
+  } = updated.doctorUser;
+
+  return c.json(
+    {
+      appointment: {
+        ...updated.appointment,
+        createdAt: new Date(updated.appointment.createdAt).toISOString(),
+        updatedAt: new Date(updated.appointment.updatedAt).toISOString(),
+        patient: { ...updated.patient, user: patientUserSafe },
+        doctor: { ...updated.doctor, user: doctorUserSafe },
+      },
+    },
+    200
+  );
+});
+
 const DAY_NAMES = [
   "sunday",
   "monday",

--- a/apps/api/src/routes/appointments.ts
+++ b/apps/api/src/routes/appointments.ts
@@ -558,11 +558,11 @@ appointmentsRoute.openapi(createAppointmentRoute, async (c) => {
   const todayJakarta = new Date().toLocaleDateString("sv-SE", {
     timeZone: "Asia/Jakarta",
   });
-  const maxDate = new Date();
-  maxDate.setDate(maxDate.getDate() + 60);
-  const maxDateJakarta = maxDate.toLocaleDateString("sv-SE", {
-    timeZone: "Asia/Jakarta",
-  });
+  // Derive max date from the Jakarta-local today so the +60 day arithmetic is
+  // never skewed by a UTC/Jakarta day boundary (happens between 17:00–00:00 UTC).
+  const maxDateObj = new Date(todayJakarta);
+  maxDateObj.setUTCDate(maxDateObj.getUTCDate() + 60);
+  const maxDateJakarta = maxDateObj.toISOString().substring(0, 10);
 
   if (appointmentDate < todayJakarta) {
     return c.json(

--- a/apps/api/src/routes/appointments.ts
+++ b/apps/api/src/routes/appointments.ts
@@ -1,15 +1,297 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { eq, and } from "drizzle-orm";
+import { eq, and, gte, lte, desc, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { db } from "../db";
-import { appointments, patients, doctors, doctorSchedules } from "../db/schema";
+import {
+  appointments,
+  patients,
+  doctors,
+  doctorSchedules,
+  users,
+} from "../db/schema";
 import { requireAuth, requireRole } from "../middleware/auth";
 import { computeAvailableSlots } from "../lib/schedule-service";
-import { APPOINTMENT_TYPES } from "@caresync/shared";
+import { APPOINTMENT_TYPES, APPOINTMENT_STATUSES } from "@caresync/shared";
 import type { AppEnv } from "../app";
 
 export const appointmentsRoute = new OpenAPIHono<AppEnv>();
 
 const errorResponse = z.object({ message: z.string() });
+
+// ─── Shared sub-schemas ───────────────────────────────────────────────────────
+
+const userInApptSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  role: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  phone: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  isActive: z.boolean(),
+});
+
+const patientInApptSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  dateOfBirth: z.string().nullable(),
+  gender: z.string().nullable(),
+  bloodType: z.string().nullable(),
+  allergies: z.string().nullable(),
+  emergencyContactName: z.string().nullable(),
+  emergencyContactPhone: z.string().nullable(),
+  user: userInApptSchema,
+});
+
+const doctorInApptSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  departmentId: z.string(),
+  specialization: z.string(),
+  bio: z.string().nullable(),
+  licenseNumber: z.string(),
+  user: userInApptSchema,
+});
+
+// ─── GET /appointments ────────────────────────────────────────────────────────
+
+const listAppointmentsQuery = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(10),
+  status: z.enum(APPOINTMENT_STATUSES).optional(),
+  from: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  to: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+const listAppointmentItemSchema = z.object({
+  id: z.string(),
+  patientId: z.string(),
+  doctorId: z.string(),
+  appointmentDate: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  status: z.string(),
+  type: z.string(),
+  reason: z.string().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  patientName: z.string(),
+  doctorName: z.string(),
+  doctorSpecialization: z.string(),
+});
+
+const listAppointmentsResponse = z.object({
+  data: z.array(listAppointmentItemSchema),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+});
+
+const listAppointmentsRoute = createRoute({
+  method: "get",
+  path: "/appointments",
+  tags: ["Appointments"],
+  summary: "List appointments (role-filtered)",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth] as const,
+  request: { query: listAppointmentsQuery },
+  responses: {
+    200: {
+      description: "Paginated appointment list",
+      content: { "application/json": { schema: listAppointmentsResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+appointmentsRoute.openapi(listAppointmentsRoute, async (c) => {
+  const { page, limit, status, from, to } = c.req.valid("query");
+  const userId = c.get("userId");
+  const userRole = c.get("userRole");
+
+  const patientUser = alias(users, "patient_user");
+  const doctorUser = alias(users, "doctor_user");
+
+  const conditions: SQL[] = [];
+  if (userRole === "patient") conditions.push(eq(patients.userId, userId));
+  if (userRole === "doctor") conditions.push(eq(doctors.userId, userId));
+  if (status) conditions.push(eq(appointments.status, status));
+  if (from) conditions.push(gte(appointments.appointmentDate, from));
+  if (to) conditions.push(lte(appointments.appointmentDate, to));
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [countResult] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(appointments)
+    .innerJoin(patients, eq(appointments.patientId, patients.id))
+    .innerJoin(patientUser, eq(patients.userId, patientUser.id))
+    .innerJoin(doctors, eq(appointments.doctorId, doctors.id))
+    .innerJoin(doctorUser, eq(doctors.userId, doctorUser.id))
+    .where(whereClause)
+    .limit(1);
+
+  const total = Number(countResult?.count ?? 0);
+
+  const rows = await db
+    .select({
+      appointment: appointments,
+      patientFirstName: patientUser.firstName,
+      patientLastName: patientUser.lastName,
+      patientUserId: patients.userId,
+      doctorFirstName: doctorUser.firstName,
+      doctorLastName: doctorUser.lastName,
+      doctorUserId: doctors.userId,
+      doctorSpecialization: doctors.specialization,
+    })
+    .from(appointments)
+    .innerJoin(patients, eq(appointments.patientId, patients.id))
+    .innerJoin(patientUser, eq(patients.userId, patientUser.id))
+    .innerJoin(doctors, eq(appointments.doctorId, doctors.id))
+    .innerJoin(doctorUser, eq(doctors.userId, doctorUser.id))
+    .where(whereClause)
+    .orderBy(desc(appointments.createdAt))
+    .limit(limit)
+    .offset((page - 1) * limit);
+
+  const data = rows.map((row) => ({
+    ...row.appointment,
+    createdAt: new Date(row.appointment.createdAt).toISOString(),
+    updatedAt: new Date(row.appointment.updatedAt).toISOString(),
+    patientName: `${row.patientFirstName} ${row.patientLastName}`,
+    doctorName: `${row.doctorFirstName} ${row.doctorLastName}`,
+    doctorSpecialization: row.doctorSpecialization,
+  }));
+
+  return c.json(
+    {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    },
+    200
+  );
+});
+
+// ─── GET /appointments/:id ────────────────────────────────────────────────────
+
+const appointmentDetailResponse = z.object({
+  id: z.string(),
+  patientId: z.string(),
+  doctorId: z.string(),
+  appointmentDate: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  status: z.string(),
+  type: z.string(),
+  reason: z.string().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  patient: patientInApptSchema,
+  doctor: doctorInApptSchema,
+});
+
+const getAppointmentRoute = createRoute({
+  method: "get",
+  path: "/appointments/{id}",
+  tags: ["Appointments"],
+  summary: "Get appointment detail",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth] as const,
+  request: { params: z.object({ id: z.string().uuid() }) },
+  responses: {
+    200: {
+      description: "Appointment detail",
+      content: { "application/json": { schema: appointmentDetailResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+appointmentsRoute.openapi(getAppointmentRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const userId = c.get("userId");
+  const userRole = c.get("userRole");
+
+  const patientUser = alias(users, "patient_user");
+  const doctorUser = alias(users, "doctor_user");
+
+  const rows = await db
+    .select({
+      appointment: appointments,
+      patient: patients,
+      patientUser: patientUser,
+      doctor: doctors,
+      doctorUser: doctorUser,
+    })
+    .from(appointments)
+    .innerJoin(patients, eq(appointments.patientId, patients.id))
+    .innerJoin(patientUser, eq(patients.userId, patientUser.id))
+    .innerJoin(doctors, eq(appointments.doctorId, doctors.id))
+    .innerJoin(doctorUser, eq(doctors.userId, doctorUser.id))
+    .where(eq(appointments.id, id))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return c.json({ message: "Appointment not found" }, 404);
+
+  if (userRole === "patient" && row.patient.userId !== userId) {
+    return c.json({ message: "Forbidden" }, 403);
+  }
+  if (userRole === "doctor" && row.doctor.userId !== userId) {
+    return c.json({ message: "Forbidden" }, 403);
+  }
+
+  const {
+    passwordHash: _ph1,
+    createdAt: _pc,
+    updatedAt: _pu,
+    ...patientUserSafe
+  } = row.patientUser;
+  const {
+    passwordHash: _ph2,
+    createdAt: _dc,
+    updatedAt: _du,
+    ...doctorUserSafe
+  } = row.doctorUser;
+
+  return c.json(
+    {
+      ...row.appointment,
+      createdAt: new Date(row.appointment.createdAt).toISOString(),
+      updatedAt: new Date(row.appointment.updatedAt).toISOString(),
+      patient: { ...row.patient, user: patientUserSafe },
+      doctor: { ...row.doctor, user: doctorUserSafe },
+    },
+    200
+  );
+});
 
 const DAY_NAMES = [
   "sunday",

--- a/apps/e2e/tests/appointment-management.spec.ts
+++ b/apps/e2e/tests/appointment-management.spec.ts
@@ -1,0 +1,458 @@
+import { type APIRequestContext } from "@playwright/test";
+import { test, expect, CleanupHelper } from "./utils/test-base";
+import { faker } from "@faker-js/faker";
+import { config } from "./utils/config";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getNextMonday(): string {
+  const d = new Date();
+  const day = d.getUTCDay();
+  const daysToAdd = day === 1 ? 7 : (8 - day) % 7;
+  d.setUTCDate(d.getUTCDate() + daysToAdd);
+  return d.toISOString().split("T")[0];
+}
+
+async function getAdminToken(request: APIRequestContext): Promise<string> {
+  const res = await request.post(`${config.apiUrl}/api/v1/auth/login`, {
+    data: { email: config.adminEmail, password: config.adminPassword },
+  });
+  const { accessToken } = await res.json();
+  return accessToken;
+}
+
+async function createDeptDoctorWithSchedule(
+  request: APIRequestContext,
+  adminToken: string,
+  cleanup: CleanupHelper
+) {
+  const deptRes = await request.post(`${config.apiUrl}/api/v1/departments`, {
+    data: { name: `Appt Mgmt Dept ${faker.string.alphanumeric(6)}` },
+    headers: { Authorization: `Bearer ${adminToken}` },
+  });
+  const dept = await deptRes.json();
+  cleanup.addDepartment(dept.id);
+
+  const doctorData = {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    email: faker.internet.email().toLowerCase(),
+    password: "Password123!",
+    departmentId: dept.id,
+    specialization: "Internal Medicine",
+    licenseNumber: faker.string.alphanumeric(10).toUpperCase(),
+  };
+
+  const doctorRes = await request.post(`${config.apiUrl}/api/v1/doctors`, {
+    data: doctorData,
+    headers: { Authorization: `Bearer ${adminToken}` },
+  });
+  const doctor = await doctorRes.json();
+  cleanup.addDoctor(doctor.id);
+
+  // Log in as doctor to set schedule
+  const doctorLoginRes = await request.post(
+    `${config.apiUrl}/api/v1/auth/login`,
+    { data: { email: doctorData.email, password: doctorData.password } }
+  );
+  const { accessToken: doctorToken, user: doctorUser } =
+    await doctorLoginRes.json();
+
+  await request.put(`${config.apiUrl}/api/v1/doctors/${doctor.id}/schedules`, {
+    data: {
+      slotDurationMinutes: 30,
+      days: [{ dayOfWeek: "monday", startTime: "09:00", endTime: "17:00" }],
+    },
+    headers: { Authorization: `Bearer ${doctorToken}` },
+  });
+
+  return { dept, doctor, doctorData, doctorToken, doctorUser };
+}
+
+async function registerPatient(
+  request: APIRequestContext,
+  cleanup: CleanupHelper
+) {
+  const credentials = {
+    email: faker.internet.email().toLowerCase(),
+    password: "Password123!",
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+  };
+  const res = await request.post(`${config.apiUrl}/api/v1/auth/register`, {
+    data: { role: "patient", ...credentials },
+  });
+  const { user: created, accessToken } = await res.json();
+  cleanup.addUser(created.id);
+  return { credentials, userId: created.id, accessToken };
+}
+
+async function bookAppointment(
+  request: APIRequestContext,
+  patientToken: string,
+  doctorId: string
+) {
+  const nextMonday = getNextMonday();
+  const slotsRes = await request.get(
+    `${config.apiUrl}/api/v1/doctors/${doctorId}/available-slots?date=${nextMonday}`,
+    { headers: { Authorization: `Bearer ${patientToken}` } }
+  );
+  const slots: string[] = await slotsRes.json();
+  if (slots.length === 0) throw new Error("No available slots for test");
+
+  const res = await request.post(`${config.apiUrl}/api/v1/appointments`, {
+    data: {
+      doctorId,
+      appointmentDate: nextMonday,
+      startTime: slots[0],
+      type: "consultation",
+      reason: "E2E test appointment",
+    },
+    headers: { Authorization: `Bearer ${patientToken}` },
+  });
+  return await res.json();
+}
+
+// ─── API tests ────────────────────────────────────────────────────────────────
+
+test.describe("Appointment Management — API", () => {
+  test("AM-A1: GET /appointments returns 200 with paginated list for patient", async ({
+    request,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    await bookAppointment(request, patientToken, doctor.id);
+
+    const res = await request.get(`${config.apiUrl}/api/v1/appointments`, {
+      headers: { Authorization: `Bearer ${patientToken}` },
+    });
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("data");
+    expect(body).toHaveProperty("total");
+    expect(body).toHaveProperty("page");
+    expect(body).toHaveProperty("totalPages");
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+
+    // List item shape
+    const item = body.data[0];
+    expect(item).toHaveProperty("patientName");
+    expect(item).toHaveProperty("doctorName");
+    expect(item).toHaveProperty("doctorSpecialization");
+    expect(item).toHaveProperty("status");
+  });
+
+  test("AM-A2: PATCH /appointments/:id/status — doctor confirms (pending → confirmed)", async ({
+    request,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor, doctorToken } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+    expect(appt.status).toBe("pending");
+
+    const patchRes = await request.patch(
+      `${config.apiUrl}/api/v1/appointments/${appt.id}/status`,
+      {
+        data: { status: "confirmed" },
+        headers: { Authorization: `Bearer ${doctorToken}` },
+      }
+    );
+
+    expect(patchRes.status()).toBe(200);
+    const body = await patchRes.json();
+    expect(body.appointment.status).toBe("confirmed");
+    expect(body.appointment.id).toBe(appt.id);
+    expect(body.appointment.patient).toBeDefined();
+    expect(body.appointment.doctor).toBeDefined();
+  });
+
+  test("AM-A3: PATCH returns 422 for invalid transition (pending → completed)", async ({
+    request,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+
+    const res = await request.patch(
+      `${config.apiUrl}/api/v1/appointments/${appt.id}/status`,
+      {
+        data: { status: "completed" },
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    );
+
+    expect(res.status()).toBe(422);
+    const body = await res.json();
+    expect(body.message).toMatch(/invalid.*transition/i);
+  });
+
+  test("AM-A4: PATCH returns 403 when patient tries to confirm", async ({
+    request,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+
+    const res = await request.patch(
+      `${config.apiUrl}/api/v1/appointments/${appt.id}/status`,
+      {
+        data: { status: "confirmed" },
+        headers: { Authorization: `Bearer ${patientToken}` },
+      }
+    );
+
+    expect(res.status()).toBe(403);
+  });
+
+  test("AM-A5: GET /appointments/:id returns full nested patient and doctor detail", async ({
+    request,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+
+    const res = await request.get(
+      `${config.apiUrl}/api/v1/appointments/${appt.id}`,
+      { headers: { Authorization: `Bearer ${patientToken}` } }
+    );
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(appt.id);
+    expect(body.patient).toBeDefined();
+    expect(body.patient.user).toBeDefined();
+    expect(body.patient.user.passwordHash).toBeUndefined();
+    expect(body.doctor).toBeDefined();
+    expect(body.doctor.user).toBeDefined();
+    expect(body.doctor.user.passwordHash).toBeUndefined();
+  });
+});
+
+// ─── UI tests ─────────────────────────────────────────────────────────────────
+
+test.describe("Appointment Management — UI", () => {
+  test("AM-1: Patient sees their appointments on /appointments list", async ({
+    page,
+    request,
+    loginPage,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { credentials, accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+
+    await loginPage.goto();
+    await loginPage.login(credentials.email, credentials.password);
+    await page.waitForURL("/dashboard");
+
+    await page.goto("/appointments");
+    await expect(page.getByTestId("appointments-page")).toBeVisible();
+
+    // The appointment row should be visible
+    await expect(page.getByTestId(`appointment-row-${appt.id}`)).toBeVisible();
+
+    // Status badge should show "pending"
+    await expect(page.getByTestId(`appointment-row-${appt.id}`)).toContainText(
+      "Pending"
+    );
+  });
+
+  test("AM-2: Status filter limits visible appointments", async ({
+    page,
+    request,
+    loginPage,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { credentials, accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+
+    await loginPage.goto();
+    await loginPage.login(credentials.email, credentials.password);
+    await page.waitForURL("/dashboard");
+
+    await page.goto("/appointments");
+
+    // Filter to "confirmed" — should not show the pending appointment
+    await page.getByTestId("status-filter").selectOption("confirmed");
+    await page.waitForURL(/status=confirmed/);
+
+    await expect(
+      page.getByTestId(`appointment-row-${appt.id}`)
+    ).not.toBeVisible();
+
+    // Switch back to "pending" — should show it
+    await page.getByTestId("status-filter").selectOption("pending");
+    await expect(page.getByTestId(`appointment-row-${appt.id}`)).toBeVisible();
+  });
+
+  test("AM-3: Doctor confirms appointment and status badge updates", async ({
+    page,
+    request,
+    loginPage,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor, doctorData } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+
+    // Log in as doctor
+    await loginPage.goto();
+    await loginPage.login(doctorData.email, doctorData.password);
+    await page.waitForURL("/dashboard");
+
+    // Navigate to the appointment detail
+    await page.goto(`/appointments/${appt.id}`);
+    await expect(page.getByTestId("appointment-detail-page")).toBeVisible();
+
+    // Status badge should show pending
+    await expect(page.getByTestId("status-badge-pending")).toBeVisible();
+
+    // Click Confirm
+    await page.getByTestId("action-confirmed").click();
+
+    // Badge should update to confirmed (no page reload needed)
+    await expect(page.getByTestId("status-badge-confirmed")).toBeVisible();
+    await expect(page.getByTestId("status-badge-pending")).not.toBeVisible();
+
+    // Confirm button should be gone (no more valid doctor transitions from confirmed except start)
+    await expect(page.getByTestId("action-confirmed")).not.toBeVisible();
+    await expect(page.getByTestId("action-in-progress")).toBeVisible();
+  });
+
+  test("AM-4: Patient cancels appointment with confirmation dialog", async ({
+    page,
+    request,
+    loginPage,
+    cleanup,
+  }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+
+    const adminToken = await getAdminToken(request);
+    const { doctor } = await createDeptDoctorWithSchedule(
+      request,
+      adminToken,
+      cleanup
+    );
+    const { credentials, accessToken: patientToken } = await registerPatient(
+      request,
+      cleanup
+    );
+
+    const appt = await bookAppointment(request, patientToken, doctor.id);
+
+    await loginPage.goto();
+    await loginPage.login(credentials.email, credentials.password);
+    await page.waitForURL("/dashboard");
+
+    await page.goto(`/appointments/${appt.id}`);
+    await expect(page.getByTestId("appointment-detail-page")).toBeVisible();
+
+    // Accept the confirmation dialog automatically
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // Click Cancel Appointment
+    await page.getByTestId("action-cancelled").click();
+
+    // Status badge should update to cancelled
+    await expect(page.getByTestId("status-badge-cancelled")).toBeVisible();
+
+    // Cancel button should be gone (terminal state)
+    await expect(page.getByTestId("appointment-actions")).not.toBeVisible();
+  });
+});

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -10,6 +10,7 @@ import { DoctorProfilePage } from "@/pages/doctor-profile";
 import { PatientsPage } from "@/pages/patients";
 import { BookAppointmentPage } from "@/pages/book-appointment";
 import { AppointmentsPage } from "@/pages/appointments";
+import { AppointmentDetailPage } from "@/pages/appointments/detail";
 import { ProtectedRoute } from "@/components/auth/protected-route";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -34,6 +35,7 @@ export function App() {
           <Route path="/doctors/:id" element={<DoctorProfilePage />} />
           <Route path="/patients" element={<PatientsPage />} />
           <Route path="/appointments" element={<AppointmentsPage />} />
+          <Route path="/appointments/:id" element={<AppointmentDetailPage />} />
           <Route path="/appointments/book" element={<PatientOnlyRoute />} />
           {/* Additional routes will be added per task */}
         </Route>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -9,6 +9,7 @@ import { DoctorsPage } from "@/pages/doctors";
 import { DoctorProfilePage } from "@/pages/doctor-profile";
 import { PatientsPage } from "@/pages/patients";
 import { BookAppointmentPage } from "@/pages/book-appointment";
+import { AppointmentsPage } from "@/pages/appointments";
 import { ProtectedRoute } from "@/components/auth/protected-route";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -32,6 +33,7 @@ export function App() {
           <Route path="/doctors" element={<DoctorsPage />} />
           <Route path="/doctors/:id" element={<DoctorProfilePage />} />
           <Route path="/patients" element={<PatientsPage />} />
+          <Route path="/appointments" element={<AppointmentsPage />} />
           <Route path="/appointments/book" element={<PatientOnlyRoute />} />
           {/* Additional routes will be added per task */}
         </Route>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -288,9 +288,51 @@ export interface CreateAppointmentInput {
   notes?: string;
 }
 
+export interface AppointmentListItem extends Appointment {
+  patientName: string;
+  doctorName: string;
+  doctorSpecialization: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListAppointmentsParams {
+  page?: number;
+  limit?: number;
+  status?: string;
+  from?: string;
+  to?: string;
+}
+
 export const appointmentsApi = {
   create: async (data: CreateAppointmentInput): Promise<Appointment> => {
     const res = await apiClient.post<Appointment>("/api/v1/appointments", data);
+    return res.data;
+  },
+
+  list: async (
+    params?: ListAppointmentsParams
+  ): Promise<PaginatedResponse<AppointmentListItem>> => {
+    const res = await apiClient.get<PaginatedResponse<AppointmentListItem>>(
+      "/api/v1/appointments",
+      { params }
+    );
+    return res.data;
+  },
+
+  get: async (id: string): Promise<Appointment> => {
+    const res = await apiClient.get<Appointment>(`/api/v1/appointments/${id}`);
+    return res.data;
+  },
+
+  updateStatus: async (
+    id: string,
+    status: string
+  ): Promise<{ appointment: Appointment }> => {
+    const res = await apiClient.patch<{ appointment: Appointment }>(
+      `/api/v1/appointments/${id}/status`,
+      { status }
+    );
     return res.data;
   },
 };

--- a/apps/web/src/pages/appointments/components/StatusBadge.tsx
+++ b/apps/web/src/pages/appointments/components/StatusBadge.tsx
@@ -11,14 +11,15 @@ const STATUS_STYLES: Record<AppointmentStatus, string> = {
 
 interface StatusBadgeProps {
   status: AppointmentStatus;
+  withTestId?: boolean;
 }
 
-export function StatusBadge({ status }: StatusBadgeProps) {
+export function StatusBadge({ status, withTestId = true }: StatusBadgeProps) {
   const styles = STATUS_STYLES[status] ?? "bg-gray-100 text-gray-600";
   const label = status.charAt(0).toUpperCase() + status.slice(1);
   return (
     <span
-      data-testid={`status-badge-${status}`}
+      {...(withTestId ? { "data-testid": `status-badge-${status}` } : {})}
       className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${styles}`}
     >
       {label}

--- a/apps/web/src/pages/appointments/components/StatusBadge.tsx
+++ b/apps/web/src/pages/appointments/components/StatusBadge.tsx
@@ -1,0 +1,27 @@
+import type { AppointmentStatus } from "@caresync/shared";
+
+const STATUS_STYLES: Record<AppointmentStatus, string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  confirmed: "bg-blue-100 text-blue-800",
+  "in-progress": "bg-purple-100 text-purple-800",
+  completed: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+  "no-show": "bg-gray-100 text-gray-600",
+};
+
+interface StatusBadgeProps {
+  status: AppointmentStatus;
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const styles = STATUS_STYLES[status] ?? "bg-gray-100 text-gray-600";
+  const label = status.charAt(0).toUpperCase() + status.slice(1);
+  return (
+    <span
+      data-testid={`status-badge-${status}`}
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${styles}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/pages/appointments/detail.tsx
+++ b/apps/web/src/pages/appointments/detail.tsx
@@ -1,0 +1,299 @@
+import { useState, useEffect } from "react";
+import { useParams, Link, useNavigate } from "react-router";
+import { appointmentsApi } from "@/lib/api-client";
+import { useAuthStore } from "@/stores/auth-store";
+import type { Appointment, AppointmentStatus } from "@caresync/shared";
+import { StatusBadge } from "./components/StatusBadge";
+
+// ─── Role + status-aware action buttons ───────────────────────────────────────
+
+interface ActionButton {
+  label: string;
+  targetStatus: AppointmentStatus;
+  destructive?: boolean;
+}
+
+function getActions(
+  role: string | undefined,
+  currentStatus: AppointmentStatus
+): ActionButton[] {
+  if (role === "patient") {
+    if (currentStatus === "pending" || currentStatus === "confirmed") {
+      return [
+        {
+          label: "Cancel Appointment",
+          targetStatus: "cancelled",
+          destructive: true,
+        },
+      ];
+    }
+    return [];
+  }
+
+  if (role === "doctor") {
+    const map: Partial<Record<AppointmentStatus, ActionButton[]>> = {
+      pending: [{ label: "Confirm", targetStatus: "confirmed" }],
+      confirmed: [{ label: "Start Appointment", targetStatus: "in-progress" }],
+      "in-progress": [{ label: "Mark Completed", targetStatus: "completed" }],
+    };
+    return map[currentStatus] ?? [];
+  }
+
+  if (role === "admin") {
+    const map: Partial<Record<AppointmentStatus, ActionButton[]>> = {
+      pending: [
+        { label: "Confirm", targetStatus: "confirmed" },
+        { label: "Cancel", targetStatus: "cancelled", destructive: true },
+      ],
+      confirmed: [
+        { label: "Start", targetStatus: "in-progress" },
+        { label: "Cancel", targetStatus: "cancelled", destructive: true },
+      ],
+      "in-progress": [
+        { label: "Complete", targetStatus: "completed" },
+        { label: "Cancel", targetStatus: "cancelled", destructive: true },
+      ],
+    };
+    return map[currentStatus] ?? [];
+  }
+
+  return [];
+}
+
+// ─── Detail row helper ─────────────────────────────────────────────────────────
+
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:gap-4 py-3 border-b border-border last:border-0">
+      <dt className="w-40 shrink-0 text-sm font-medium text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="text-sm text-foreground mt-1 sm:mt-0">{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export function AppointmentDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const user = useAuthStore((s) => s.user);
+
+  const [appointment, setAppointment] = useState<Appointment | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [updating, setUpdating] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    appointmentsApi
+      .get(id)
+      .then((data) => setAppointment(data))
+      .catch(() => setError("Appointment not found or you don't have access."))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  async function handleStatusChange(
+    targetStatus: AppointmentStatus,
+    destructive?: boolean
+  ) {
+    if (!appointment || !id) return;
+
+    if (destructive) {
+      const confirmed = window.confirm(
+        `Are you sure you want to ${targetStatus === "cancelled" ? "cancel" : "update"} this appointment? This action cannot be undone.`
+      );
+      if (!confirmed) return;
+    }
+
+    setUpdating(true);
+    setActionError(null);
+    try {
+      const res = await appointmentsApi.updateStatus(id, targetStatus);
+      setAppointment(res.appointment);
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.message ?? "Failed to update appointment status.";
+      setActionError(msg);
+    } finally {
+      setUpdating(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div
+        data-testid="appointment-detail-loading"
+        className="flex items-center justify-center py-24 text-muted-foreground"
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (error || !appointment) {
+    return (
+      <div data-testid="appointment-detail-error" className="py-8">
+        <p className="text-red-600 mb-4">{error ?? "Appointment not found."}</p>
+        <Link
+          to="/appointments"
+          className="text-sm text-primary hover:underline"
+        >
+          ← Back to appointments
+        </Link>
+      </div>
+    );
+  }
+
+  const status = appointment.status as AppointmentStatus;
+  const actions = getActions(user?.role, status);
+
+  const patient = appointment.patient as any;
+  const doctor = appointment.doctor as any;
+
+  return (
+    <div data-testid="appointment-detail-page">
+      {/* Header */}
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <Link
+            to="/appointments"
+            data-testid="back-to-appointments"
+            className="mb-2 inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            ← Back to appointments
+          </Link>
+          <h1 className="text-2xl font-bold text-foreground">
+            Appointment Detail
+          </h1>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+
+      {/* Action error */}
+      {actionError && (
+        <div
+          data-testid="action-error"
+          className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
+          {actionError}
+        </div>
+      )}
+
+      {/* Action buttons */}
+      {actions.length > 0 && (
+        <div
+          data-testid="appointment-actions"
+          className="mb-6 flex flex-wrap gap-3"
+        >
+          {actions.map((action) => (
+            <button
+              key={action.targetStatus}
+              data-testid={`action-${action.targetStatus}`}
+              disabled={updating}
+              onClick={() =>
+                handleStatusChange(action.targetStatus, action.destructive)
+              }
+              className={`rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
+                action.destructive
+                  ? "bg-red-600 text-white hover:bg-red-700"
+                  : "bg-primary text-primary-foreground hover:bg-primary/90"
+              }`}
+            >
+              {updating ? "Updating…" : action.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Appointment info */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Appointment details */}
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h2 className="mb-4 text-base font-semibold text-foreground">
+            Appointment Info
+          </h2>
+          <dl>
+            <DetailRow label="Date" value={appointment.appointmentDate} />
+            <DetailRow
+              label="Time"
+              value={`${appointment.startTime} – ${appointment.endTime}`}
+            />
+            <DetailRow
+              label="Type"
+              value={<span className="capitalize">{appointment.type}</span>}
+            />
+            <DetailRow label="Status" value={<StatusBadge status={status} />} />
+            <DetailRow label="Reason" value={appointment.reason} />
+            <DetailRow label="Notes" value={appointment.notes} />
+          </dl>
+        </div>
+
+        {/* Patient info */}
+        {patient && (
+          <div
+            data-testid="patient-info"
+            className="rounded-lg border border-border bg-card p-6"
+          >
+            <h2 className="mb-4 text-base font-semibold text-foreground">
+              Patient
+            </h2>
+            <dl>
+              <DetailRow
+                label="Name"
+                value={`${patient.user?.firstName ?? ""} ${patient.user?.lastName ?? ""}`}
+              />
+              <DetailRow label="Email" value={patient.user?.email} />
+              <DetailRow label="Date of Birth" value={patient.dateOfBirth} />
+              <DetailRow
+                label="Gender"
+                value={<span className="capitalize">{patient.gender}</span>}
+              />
+              <DetailRow label="Blood Type" value={patient.bloodType} />
+              <DetailRow label="Allergies" value={patient.allergies} />
+              <DetailRow
+                label="Emergency Contact"
+                value={
+                  patient.emergencyContactName
+                    ? `${patient.emergencyContactName} — ${patient.emergencyContactPhone ?? ""}`
+                    : null
+                }
+              />
+            </dl>
+          </div>
+        )}
+
+        {/* Doctor info */}
+        {doctor && (
+          <div
+            data-testid="doctor-info"
+            className="rounded-lg border border-border bg-card p-6"
+          >
+            <h2 className="mb-4 text-base font-semibold text-foreground">
+              Doctor
+            </h2>
+            <dl>
+              <DetailRow
+                label="Name"
+                value={`${doctor.user?.firstName ?? ""} ${doctor.user?.lastName ?? ""}`}
+              />
+              <DetailRow label="Email" value={doctor.user?.email} />
+              <DetailRow label="Specialization" value={doctor.specialization} />
+              <DetailRow label="License" value={doctor.licenseNumber} />
+              <DetailRow label="Bio" value={doctor.bio} />
+            </dl>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/appointments/detail.tsx
+++ b/apps/web/src/pages/appointments/detail.tsx
@@ -232,7 +232,10 @@ export function AppointmentDetailPage() {
               label="Type"
               value={<span className="capitalize">{appointment.type}</span>}
             />
-            <DetailRow label="Status" value={<StatusBadge status={status} />} />
+            <DetailRow
+              label="Status"
+              value={<StatusBadge status={status} withTestId={false} />}
+            />
             <DetailRow label="Reason" value={appointment.reason} />
             <DetailRow label="Notes" value={appointment.notes} />
           </dl>

--- a/apps/web/src/pages/appointments/index.tsx
+++ b/apps/web/src/pages/appointments/index.tsx
@@ -1,0 +1,247 @@
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams, Link } from "react-router";
+import { appointmentsApi } from "@/lib/api-client";
+import type { AppointmentListItem } from "@/lib/api-client";
+import { APPOINTMENT_STATUSES } from "@caresync/shared";
+import type { AppointmentStatus } from "@caresync/shared";
+import { StatusBadge } from "./components/StatusBadge";
+
+const LIMIT = 10;
+
+export function AppointmentsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = Number(searchParams.get("page") ?? "1");
+  const status = searchParams.get("status") ?? "";
+  const from = searchParams.get("from") ?? "";
+  const to = searchParams.get("to") ?? "";
+
+  const [appointments, setAppointments] = useState<AppointmentListItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAppointments = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await appointmentsApi.list({
+        page,
+        limit: LIMIT,
+        status: status || undefined,
+        from: from || undefined,
+        to: to || undefined,
+      });
+      setAppointments(res.data);
+      setTotal(res.total);
+      setTotalPages(res.totalPages);
+    } catch {
+      setError("Failed to load appointments. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [page, status, from, to]);
+
+  useEffect(() => {
+    fetchAppointments();
+  }, [fetchAppointments]);
+
+  function setParam(key: string, value: string) {
+    const next = new URLSearchParams(searchParams);
+    if (value) {
+      next.set(key, value);
+    } else {
+      next.delete(key);
+    }
+    // Reset to page 1 when filters change
+    if (key !== "page") next.set("page", "1");
+    setSearchParams(next);
+  }
+
+  return (
+    <div data-testid="appointments-page">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Appointments</h1>
+          <p className="text-sm text-muted-foreground">
+            {total} appointment{total !== 1 ? "s" : ""} found
+          </p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex flex-wrap gap-3">
+        <select
+          data-testid="status-filter"
+          value={status}
+          onChange={(e) => setParam("status", e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">All statuses</option>
+          {APPOINTMENT_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </option>
+          ))}
+        </select>
+
+        <input
+          type="date"
+          data-testid="from-date-filter"
+          value={from}
+          onChange={(e) => setParam("from", e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <input
+          type="date"
+          data-testid="to-date-filter"
+          value={to}
+          onChange={(e) => setParam("to", e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+
+        {(status || from || to) && (
+          <button
+            data-testid="clear-filters"
+            onClick={() => setSearchParams(new URLSearchParams({ page: "1" }))}
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-muted transition-colors"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          data-testid="appointments-error"
+          className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="rounded-lg border border-border bg-card">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Date
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Patient
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Doctor
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Type
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Status
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && (
+              <tr>
+                <td
+                  colSpan={6}
+                  data-testid="appointments-loading"
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
+                  Loading…
+                </td>
+              </tr>
+            )}
+            {!loading && appointments.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  data-testid="appointments-empty"
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
+                  No appointments found.
+                </td>
+              </tr>
+            )}
+            {!loading &&
+              appointments.map((appt) => (
+                <tr
+                  key={appt.id}
+                  data-testid={`appointment-row-${appt.id}`}
+                  className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors"
+                >
+                  <td className="px-4 py-3 text-foreground">
+                    <div className="font-medium">{appt.appointmentDate}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {appt.startTime} – {appt.endTime}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-foreground">
+                    {appt.patientName}
+                  </td>
+                  <td className="px-4 py-3 text-foreground">
+                    <div>{appt.doctorName}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {appt.doctorSpecialization}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground capitalize">
+                    {appt.type}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusBadge status={appt.status as AppointmentStatus} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Link
+                      to={`/appointments/${appt.id}`}
+                      data-testid={`view-appointment-${appt.id}`}
+                      className="text-sm font-medium text-primary hover:underline"
+                    >
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div
+          data-testid="pagination"
+          className="mt-4 flex items-center justify-between"
+        >
+          <p className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <button
+              data-testid="prev-page"
+              disabled={page <= 1}
+              onClick={() => setParam("page", String(page - 1))}
+              className="rounded-md border border-input bg-background px-3 py-1.5 text-sm disabled:opacity-50 hover:bg-muted transition-colors"
+            >
+              Previous
+            </button>
+            <button
+              data-testid="next-page"
+              disabled={page >= totalPages}
+              onClick={() => setParam("page", String(page + 1))}
+              className="rounded-md border border-input bg-background px-3 py-1.5 text-sm disabled:opacity-50 hover:bg-muted transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/profile.test.tsx
+++ b/apps/web/src/pages/profile.test.tsx
@@ -139,8 +139,10 @@ describe("ProfilePage", () => {
   });
 
   it("disables the save button while submitting", async () => {
+    // Use a never-settling promise so isSubmitting stays true without
+    // leaving a real timer that fires setAuth(undefined) mid-test in CI.
     vi.mocked(usersApi.updateProfile).mockImplementation(
-      () => new Promise((resolve) => setTimeout(resolve, 500))
+      () => new Promise(() => {})
     );
     renderProfile();
 

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -246,7 +246,7 @@ export function ProfilePage() {
         lastName: data.lastName,
         phone: data.phone || null,
       });
-      if (user && accessToken) {
+      if (updated && accessToken) {
         setAuth(updated, accessToken);
       }
       setSuccess(true);
@@ -265,7 +265,7 @@ export function ProfilePage() {
       const formData = new FormData();
       formData.append("avatar", file);
       const updated = await usersApi.updateAvatar(formData);
-      if (user && accessToken) {
+      if (updated && accessToken) {
         setAuth(updated, accessToken);
       }
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- Adds `GET /appointments`, `GET /appointments/:id`, and `PATCH /appointments/:id/status` API endpoints with role-based scoping (patient/doctor/admin) and a status transition matrix (422 on invalid, 403 on unauthorized role)
- Builds `/appointments` list page with status filter, date range filter, and pagination (filters stored in URL search params)
- Builds `/appointments/:id` detail page with role-aware action buttons that update optimistically from the API response
- Adds 9 Playwright E2E tests (5 API + 4 UI) covering list, detail, confirm flow, cancel flow, status filter, and 403/422 enforcement

## Test plan

- [ ] `pnpm test` — all 212 unit tests pass
- [ ] `pnpm build` — clean compile across all packages
- [ ] Patient can view their own appointments list at `/appointments`
- [ ] Status filter updates URL params and hides non-matching rows
- [ ] Doctor can confirm a pending appointment from the detail page; badge updates without reload
- [ ] Patient can cancel a pending/confirmed appointment via confirmation dialog; terminal state removes action buttons
- [ ] Admin can drive any valid transition
- [ ] Invalid transitions return 422; patient attempting confirm returns 403
- [ ] `GET /appointments/:id` response excludes `passwordHash` on both nested user objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)