### PR TITLE
feat(medical-records): add file attachments support

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,14 +25,18 @@
     "drizzle-orm": "^0.38",
     "hono": "^4.7",
     "jsonwebtoken": "^9.0",
+    "multer": "^1.4.5-lts.1",
     "pg": "^8.13",
+    "uuid": "^11.0",
     "zod": "^3.24"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4",
     "@types/jsonwebtoken": "^9.0",
+    "@types/multer": "^1.4",
     "@types/node": "^22",
     "@types/pg": "^8.11",
+    "@types/uuid": "^10",
     "drizzle-kit": "^0.30",
     "tsx": "^4.19",
     "typescript": "^5.7",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,6 +11,7 @@ import { doctorsRoute } from "./routes/doctors";
 import { patientsRoute } from "./routes/patients";
 import { appointmentsRoute } from "./routes/appointments";
 import { medicalRecordsRoute } from "./routes/medical-records";
+import { attachmentsRoute } from "./routes/attachments";
 
 export type AppEnv = {
   Variables: {
@@ -48,6 +49,7 @@ app.route("/api/v1", doctorsRoute);
 app.route("/api/v1", patientsRoute);
 app.route("/api/v1", appointmentsRoute);
 app.route("/api/v1", medicalRecordsRoute);
+app.route("/api/v1", attachmentsRoute);
 
 // OpenAPI spec
 app.doc("/api/openapi.json", {

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -4,4 +4,6 @@ export const env = {
   JWT_REFRESH_SECRET: process.env.JWT_REFRESH_SECRET || "dev-refresh-secret",
   PORT: Number(process.env.PORT || 3000),
   IS_PRODUCTION: process.env.NODE_ENV === "production",
+  UPLOAD_DIR: process.env.UPLOAD_DIR || "./uploads",
+  MAX_FILE_SIZE: Number(process.env.MAX_FILE_SIZE || 10 * 1024 * 1024),
 };

--- a/apps/api/src/lib/file-storage.ts
+++ b/apps/api/src/lib/file-storage.ts
@@ -1,0 +1,80 @@
+import { v4 as uuidv4 } from "uuid";
+import path from "path";
+import fs from "fs";
+
+const UPLOAD_DIR = process.env.UPLOAD_DIR || "./uploads";
+const MAX_FILE_SIZE = Number(process.env.MAX_FILE_SIZE) || 10 * 1024 * 1024; // 10MB default
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+
+export interface UploadedFile {
+  originalName: string;
+  storedName: string;
+  mimeType: string;
+  size: number;
+  url: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function validateFile(mimeType: string, size: number): ValidationResult {
+  if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+    return {
+      valid: false,
+      error: `File type not allowed. Allowed types: ${ALLOWED_MIME_TYPES.join(", ")}`,
+    };
+  }
+
+  if (size > MAX_FILE_SIZE) {
+    return {
+      valid: false,
+      error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
+    };
+  }
+
+  return { valid: true };
+}
+
+export function generateStoredFileName(originalName: string): string {
+  const ext = path.extname(originalName).toLowerCase();
+  const uuid = uuidv4();
+  return `${uuid}${ext}`;
+}
+
+export function getFileUrl(storedName: string): string {
+  return `/uploads/attachments/${storedName}`;
+}
+
+export async function saveFile(
+  buffer: Buffer,
+  storedName: string
+): Promise<string> {
+  const attachmentsDir = path.join(UPLOAD_DIR, "attachments");
+
+  // Ensure directory exists
+  if (!fs.existsSync(attachmentsDir)) {
+    fs.mkdirSync(attachmentsDir, { recursive: true });
+  }
+
+  const filePath = path.join(attachmentsDir, storedName);
+  await fs.promises.writeFile(filePath, buffer);
+
+  return getFileUrl(storedName);
+}
+
+export async function deleteFile(storedName: string): Promise<void> {
+  const filePath = path.join(UPLOAD_DIR, "attachments", storedName);
+  if (fs.existsSync(filePath)) {
+    await fs.promises.unlink(filePath);
+  }
+}

--- a/apps/api/src/lib/upload.ts
+++ b/apps/api/src/lib/upload.ts
@@ -1,0 +1,90 @@
+import multer from "multer";
+import { createMiddleware } from "hono/factory";
+import {
+  validateFile,
+  generateStoredFileName,
+  saveFile,
+  type UploadedFile,
+} from "./file-storage";
+import type { AppEnv } from "../app";
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 10 * 1024 * 1024,
+    files: 1,
+  },
+  fileFilter: (_req, file, cb) => {
+    const allowed = [
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+      "application/pdf",
+      "text/plain",
+      "application/msword",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`File type not allowed: ${file.mimetype}`));
+    }
+  },
+});
+
+export type FileUploadCtx = AppEnv & {
+  Variables: {
+    uploadedFile: UploadedFile;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function runMulter(
+  req: Request,
+  uploadInst: any
+): Promise<{ file: Express.Multer.File } | { error: string }> {
+  return new Promise((resolve) => {
+    uploadInst.single("file")(req as any, {} as any, (err: any) => {
+      if (err) {
+        resolve({ error: err.message || "Upload failed" });
+      } else {
+        const file = (req as any).file;
+        if (!file) {
+          resolve({ error: "No file provided" });
+        } else {
+          resolve({ file });
+        }
+      }
+    });
+  });
+}
+
+export const uploadMiddleware = createMiddleware<FileUploadCtx>(
+  async (c, next) => {
+    const result = await runMulter(c.req.raw, upload);
+
+    if ("error" in result) {
+      return c.json({ message: result.error }, 400);
+    }
+
+    const { file } = result;
+    const validation = validateFile(file.mimetype, file.size);
+    if (!validation.valid) {
+      return c.json({ message: validation.error }, 400);
+    }
+
+    const storedName = generateStoredFileName(file.originalname);
+    const url = await saveFile(file.buffer, storedName);
+
+    const uploadedFile: UploadedFile = {
+      originalName: file.originalname,
+      storedName,
+      mimeType: file.mimetype,
+      size: file.size,
+      url,
+    };
+
+    c.set("uploadedFile", uploadedFile);
+    await next();
+  }
+);

--- a/apps/api/src/routes/attachments.ts
+++ b/apps/api/src/routes/attachments.ts
@@ -1,0 +1,412 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq, and } from "drizzle-orm";
+import { db } from "../db";
+import {
+  medicalRecordAttachments,
+  medicalRecords,
+  appointments,
+  patients,
+  doctors,
+  users,
+} from "../db/schema";
+import { requireAuth, requireRole } from "../middleware/auth";
+import { uploadMiddleware } from "../lib/upload";
+import { deleteFile } from "../lib/file-storage";
+import type { AppEnv } from "../app";
+
+export const attachmentsRoute = new OpenAPIHono<AppEnv>();
+
+attachmentsRoute.use("/medical-records/:recordId/attachments", requireAuth);
+attachmentsRoute.use("/medical-records/:recordId/attachments/*", requireAuth);
+
+// ─── Shared schemas ────────────────────────────────────────────────────────────
+
+const errorResponse = z.object({ message: z.string() });
+
+const attachmentSchema = z.object({
+  id: z.string(),
+  medicalRecordId: z.string(),
+  fileName: z.string(),
+  fileUrl: z.string(),
+  fileType: z.string(),
+  fileSize: z.number(),
+});
+
+const recordIdParam = z.object({ recordId: z.string().uuid() });
+const attachmentIdParam = z.object({
+  recordId: z.string().uuid(),
+  attachmentId: z.string().uuid(),
+});
+
+// ─── POST /medical-records/:recordId/attachments ────────────────────────────────
+
+const uploadAttachmentRoute = createRoute({
+  method: "post",
+  path: "/medical-records/{recordId}/attachments",
+  tags: ["Medical Record Attachments"],
+  summary: "Upload an attachment to a medical record (doctor only)",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireRole("doctor"), uploadMiddleware] as const,
+  request: {
+    params: recordIdParam,
+  },
+  responses: {
+    201: {
+      description: "Attachment uploaded",
+      content: {
+        "application/json": { schema: attachmentSchema },
+      },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Medical record not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+attachmentsRoute.openapi(uploadAttachmentRoute, async (c) => {
+  const userId = c.get("userId");
+  const { recordId } = c.req.valid("param");
+  const uploadedFile = c.get("uploadedFile");
+
+  // Fetch medical record
+  const [record] = await db
+    .select({
+      id: medicalRecords.id,
+      doctorId: medicalRecords.doctorId,
+      appointmentId: medicalRecords.appointmentId,
+    })
+    .from(medicalRecords)
+    .where(eq(medicalRecords.id, recordId))
+    .limit(1);
+
+  if (!record) {
+    return c.json({ message: "Medical record not found" }, 404);
+  }
+
+  // Verify the requesting doctor owns this record
+  const [doctor] = await db
+    .select({ id: doctors.id })
+    .from(doctors)
+    .where(eq(doctors.userId, userId))
+    .limit(1);
+
+  if (!doctor || doctor.id !== record.doctorId) {
+    return c.json({ message: "Forbidden" }, 403);
+  }
+
+  // Insert attachment
+  const [created] = await db
+    .insert(medicalRecordAttachments)
+    .values({
+      medicalRecordId: recordId,
+      fileName: uploadedFile.originalName,
+      fileUrl: uploadedFile.url,
+      fileType: uploadedFile.mimeType,
+      fileSize: uploadedFile.size,
+    })
+    .returning();
+
+  return c.json(
+    {
+      id: created.id,
+      medicalRecordId: created.medicalRecordId,
+      fileName: created.fileName,
+      fileUrl: created.fileUrl,
+      fileType: created.fileType,
+      fileSize: created.fileSize,
+    },
+    201
+  );
+});
+
+// ─── GET /medical-records/:recordId/attachments ───────────────────────────────
+
+const listAttachmentsRoute = createRoute({
+  method: "get",
+  path: "/medical-records/{recordId}/attachments",
+  tags: ["Medical Record Attachments"],
+  summary: "List attachments for a medical record",
+  security: [{ bearerAuth: [] }],
+  request: { params: recordIdParam },
+  responses: {
+    200: {
+      description: "List of attachments",
+      content: {
+        "application/json": {
+          schema: z.array(attachmentSchema),
+        },
+      },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Medical record not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+attachmentsRoute.openapi(listAttachmentsRoute, async (c) => {
+  const userId = c.get("userId");
+  const role = c.get("userRole");
+  const { recordId } = c.req.valid("param");
+
+  // Fetch medical record with ownership info
+  const [record] = await db
+    .select({
+      id: medicalRecords.id,
+      patientId: medicalRecords.patientId,
+      doctorId: medicalRecords.doctorId,
+    })
+    .from(medicalRecords)
+    .where(eq(medicalRecords.id, recordId))
+    .limit(1);
+
+  if (!record) {
+    return c.json({ message: "Medical record not found" }, 404);
+  }
+
+  // Check access permissions
+  if (role === "patient") {
+    const [patient] = await db
+      .select({ id: patients.id })
+      .from(patients)
+      .where(eq(patients.userId, userId))
+      .limit(1);
+    if (!patient || patient.id !== record.patientId) {
+      return c.json({ message: "Forbidden" }, 403);
+    }
+  } else if (role === "doctor") {
+    const [doctor] = await db
+      .select({ id: doctors.id })
+      .from(doctors)
+      .where(eq(doctors.userId, userId))
+      .limit(1);
+    if (!doctor || doctor.id !== record.doctorId) {
+      return c.json({ message: "Forbidden" }, 403);
+    }
+  }
+  // admin bypasses ownership check
+
+  const rows = await db
+    .select()
+    .from(medicalRecordAttachments)
+    .where(eq(medicalRecordAttachments.medicalRecordId, recordId));
+
+  return c.json(
+    rows.map((r) => ({
+      id: r.id,
+      medicalRecordId: r.medicalRecordId,
+      fileName: r.fileName,
+      fileUrl: r.fileUrl,
+      fileType: r.fileType,
+      fileSize: r.fileSize,
+    })),
+    200
+  );
+});
+
+// ─── GET /medical-records/:recordId/attachments/:attachmentId ───────────────
+
+const getAttachmentRoute = createRoute({
+  method: "get",
+  path: "/medical-records/{recordId}/attachments/{attachmentId}",
+  tags: ["Medical Record Attachments"],
+  summary: "Get a specific attachment",
+  security: [{ bearerAuth: [] }],
+  request: { params: attachmentIdParam },
+  responses: {
+    200: {
+      description: "Attachment details",
+      content: {
+        "application/json": { schema: attachmentSchema },
+      },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Attachment not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+attachmentsRoute.openapi(getAttachmentRoute, async (c) => {
+  const userId = c.get("userId");
+  const role = c.get("userRole");
+  const { recordId, attachmentId } = c.req.valid("param");
+
+  const [record] = await db
+    .select({
+      id: medicalRecords.id,
+      patientId: medicalRecords.patientId,
+      doctorId: medicalRecords.doctorId,
+    })
+    .from(medicalRecords)
+    .where(eq(medicalRecords.id, recordId))
+    .limit(1);
+
+  if (!record) {
+    return c.json({ message: "Medical record not found" }, 404);
+  }
+
+  // Access check
+  if (role === "patient") {
+    const [patient] = await db
+      .select({ id: patients.id })
+      .from(patients)
+      .where(eq(patients.userId, userId))
+      .limit(1);
+    if (!patient || patient.id !== record.patientId) {
+      return c.json({ message: "Forbidden" }, 403);
+    }
+  } else if (role === "doctor") {
+    const [doctor] = await db
+      .select({ id: doctors.id })
+      .from(doctors)
+      .where(eq(doctors.userId, userId))
+      .limit(1);
+    if (!doctor || doctor.id !== record.doctorId) {
+      return c.json({ message: "Forbidden" }, 403);
+    }
+  }
+
+  const [attachment] = await db
+    .select()
+    .from(medicalRecordAttachments)
+    .where(
+      and(
+        eq(medicalRecordAttachments.id, attachmentId),
+        eq(medicalRecordAttachments.medicalRecordId, recordId)
+      )
+    )
+    .limit(1);
+
+  if (!attachment) {
+    return c.json({ message: "Attachment not found" }, 404);
+  }
+
+  return c.json(
+    {
+      id: attachment.id,
+      medicalRecordId: attachment.medicalRecordId,
+      fileName: attachment.fileName,
+      fileUrl: attachment.fileUrl,
+      fileType: attachment.fileType,
+      fileSize: attachment.fileSize,
+    },
+    200
+  );
+});
+
+// ─── DELETE /medical-records/:recordId/attachments/:attachmentId ─────────────
+
+const deleteAttachmentRoute = createRoute({
+  method: "delete",
+  path: "/medical-records/{recordId}/attachments/{attachmentId}",
+  tags: ["Medical Record Attachments"],
+  summary: "Delete an attachment (doctor only, ownership enforced)",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireRole("doctor")] as const,
+  request: { params: attachmentIdParam },
+  responses: {
+    200: {
+      description: "Attachment deleted",
+      content: {
+        "application/json": { schema: z.object({ message: z.string() }) },
+      },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Attachment not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+attachmentsRoute.openapi(deleteAttachmentRoute, async (c) => {
+  const userId = c.get("userId");
+  const { recordId, attachmentId } = c.req.valid("param");
+
+  // Get record with ownership check
+  const [record] = await db
+    .select({
+      id: medicalRecords.id,
+      doctorId: medicalRecords.doctorId,
+    })
+    .from(medicalRecords)
+    .where(eq(medicalRecords.id, recordId))
+    .limit(1);
+
+  if (!record) {
+    return c.json({ message: "Medical record not found" }, 404);
+  }
+
+  const [doctor] = await db
+    .select({ id: doctors.id })
+    .from(doctors)
+    .where(eq(doctors.userId, userId))
+    .limit(1);
+
+  if (!doctor || doctor.id !== record.doctorId) {
+    return c.json({ message: "Forbidden" }, 403);
+  }
+
+  const [attachment] = await db
+    .select()
+    .from(medicalRecordAttachments)
+    .where(
+      and(
+        eq(medicalRecordAttachments.id, attachmentId),
+        eq(medicalRecordAttachments.medicalRecordId, recordId)
+      )
+    )
+    .limit(1);
+
+  if (!attachment) {
+    return c.json({ message: "Attachment not found" }, 404);
+  }
+
+  // Delete file from storage
+  const storedName = attachment.fileUrl.split("/").pop() || "";
+  await deleteFile(storedName);
+
+  // Delete from database
+  await db
+    .delete(medicalRecordAttachments)
+    .where(eq(medicalRecordAttachments.id, attachmentId));
+
+  return c.json({ message: "Attachment deleted" }, 200);
+});

--- a/apps/e2e/tests/medical-records.spec.ts
+++ b/apps/e2e/tests/medical-records.spec.ts
@@ -239,6 +239,422 @@ test.describe("Medical Records — API", () => {
   });
 });
 
+// ─── File attachment helpers ───────────────────────────────────────────────────
+
+/**
+ * Creates a small in-memory text file and returns it as a {name, buffer, mimeType}.
+ * Playwright's locator.setInputFiles() accepts file paths OR buffer metadata, so we
+ * write the temp file to disk first – that is what the browser's file input expects.
+ */
+async function makeTempFile(
+  name: string,
+  content: string,
+  mimeType: string
+): Promise<{ filePath: string; mimeType: string }> {
+  const tmpDir = process.env.TEMP || "/tmp";
+  const filePath = `${tmpDir}/${name}`;
+  const { writeFile } = await import("fs/promises");
+  await writeFile(filePath, content);
+  return { filePath, mimeType };
+}
+
+// ─── API tests ────────────────────────────────────────────────────────────────
+
+test.describe("Medical Record Attachments — API", () => {
+  let adminToken: string;
+  let doctorToken: string;
+  let patientToken: string;
+  let recordId: string;
+  let doctorData: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    password: string;
+  };
+
+  test.beforeAll(async ({ request }) => {
+    test.skip(!config.adminEmail, "Set ADMIN_EMAIL + ADMIN_PASSWORD env vars");
+    adminToken = await getAdminToken(request);
+
+    // Create doctor + department
+    const deptRes = await request.post(`${config.apiUrl}/api/v1/departments`, {
+      data: { name: `MR Attch Dept ${faker.string.alphanumeric(6)}` },
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const dept = await deptRes.json();
+
+    doctorData = {
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      email: faker.internet.email().toLowerCase(),
+      password: "Password123!",
+    };
+
+    const doctorRes = await request.post(`${config.apiUrl}/api/v1/doctors`, {
+      data: {
+        ...doctorData,
+        departmentId: dept.id,
+        specialization: "General Medicine",
+        licenseNumber: faker.string.alphanumeric(10).toUpperCase(),
+      },
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const doctor = await doctorRes.json();
+
+    const doctorLoginRes = await request.post(
+      `${config.apiUrl}/api/v1/auth/login`,
+      { data: { email: doctorData.email, password: doctorData.password } }
+    );
+    doctorToken = (await doctorLoginRes.json()).accessToken;
+
+    // Register patient
+    const patientEmail = faker.internet.email().toLowerCase();
+    const patientRes = await request.post(
+      `${config.apiUrl}/api/v1/auth/register`,
+      {
+        data: {
+          role: "patient",
+          email: patientEmail,
+          password: "Password123!",
+          firstName: faker.person.firstName(),
+          lastName: faker.person.lastName(),
+        },
+      }
+    );
+    patientToken = (await patientRes.json()).accessToken;
+
+    // Create a completed appointment and medical record
+    const nextMonday = getNextMonday();
+
+    const slotsRes = await request.get(
+      `${config.apiUrl}/api/v1/doctors/${doctor.id}/available-slots?date=${nextMonday}`,
+      { headers: { Authorization: `Bearer ${patientToken}` } }
+    );
+    const slots: string[] = await slotsRes.json();
+    expect(slots.length).toBeGreaterThan(0);
+
+    const apptRes = await request.post(`${config.apiUrl}/api/v1/appointments`, {
+      data: {
+        doctorId: doctor.id,
+        appointmentDate: nextMonday,
+        startTime: slots[0],
+        type: "consultation",
+        reason: "E2E attachment test",
+      },
+      headers: { Authorization: `Bearer ${patientToken}` },
+    });
+    const appt = await apptRes.json();
+
+    for (const status of ["confirmed", "in-progress", "completed"] as const) {
+      await request.patch(
+        `${config.apiUrl}/api/v1/appointments/${appt.id}/status`,
+        {
+          data: { status },
+          headers: { Authorization: `Bearer ${doctorToken}` },
+        }
+      );
+    }
+
+    const mrRes = await request.post(
+      `${config.apiUrl}/api/v1/medical-records`,
+      {
+        data: {
+          appointmentId: appt.id,
+          diagnosis: "E2E Attachment Test Diagnosis",
+          symptoms: "None",
+          notes: "Test record for attachment flow",
+        },
+        headers: { Authorization: `Bearer ${doctorToken}` },
+      }
+    );
+    const mr = await mrRes.json();
+    recordId = mr.id;
+  });
+
+  test("MR-ATT-A1: POST uploads a file attachment and GET returns it", async ({
+    request,
+  }) => {
+    // Create a temp text file
+    const { filePath, mimeType } = await makeTempFile(
+      `test-attachment-${Date.now()}.txt`,
+      "Lab result: Normal blood panel",
+      "text/plain"
+    );
+
+    const uploadRes = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${doctorToken}` },
+        multipart: {
+          file: {
+            name: `test-attachment-${Date.now()}.txt`,
+            mimeType,
+            buffer: Buffer.from("Lab result: Normal blood panel"),
+          },
+        },
+      }
+    );
+
+    expect(uploadRes.status()).toBe(201);
+    const attachment = await uploadRes.json();
+    expect(attachment.medicalRecordId).toBe(recordId);
+    expect(attachment.fileName).toMatch(/test-attachment.*\.txt/);
+    expect(attachment.fileUrl).toMatch(/^\/uploads\/attachments\//);
+    expect(attachment.fileType).toBe("text/plain");
+    expect(attachment.fileSize).toBeGreaterThan(0);
+
+    // GET returns the attachment
+    const listRes = await request.get(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      { headers: { Authorization: `Bearer ${patientToken}` } }
+    );
+    expect(listRes.status()).toBe(200);
+    const list: unknown[] = await listRes.json();
+    expect(list.some((a: any) => a.id === attachment.id)).toBe(true);
+  });
+
+  test("MR-ATT-A2: GET /attachments/:id returns a specific attachment", async ({
+    request,
+  }) => {
+    // Upload first
+    const uploadRes = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${doctorToken}` },
+        multipart: {
+          file: {
+            name: `single-attachment-${Date.now()}.pdf`,
+            mimeType: "application/pdf",
+            buffer: Buffer.from("Mock PDF content"),
+          },
+        },
+      }
+    );
+    expect(uploadRes.status()).toBe(201);
+    const attachment = await uploadRes.json();
+
+    // Fetch by ID
+    const getRes = await request.get(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments/${attachment.id}`,
+      { headers: { Authorization: `Bearer ${patientToken}` } }
+    );
+    expect(getRes.status()).toBe(200);
+    const fetched = await getRes.json();
+    expect(fetched.id).toBe(attachment.id);
+    expect(fetched.fileName).toBe(attachment.fileName);
+  });
+
+  test("MR-ATT-A3: DELETE removes an attachment", async ({ request }) => {
+    // Upload
+    const uploadRes = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${doctorToken}` },
+        multipart: {
+          file: {
+            name: `delete-me-${Date.now()}.txt`,
+            mimeType: "text/plain",
+            buffer: Buffer.from("To be deleted"),
+          },
+        },
+      }
+    );
+    expect(uploadRes.status()).toBe(201);
+    const attachment = await uploadRes.json();
+
+    // Delete
+    const delRes = await request.delete(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments/${attachment.id}`,
+      { headers: { Authorization: `Bearer ${doctorToken}` } }
+    );
+    expect(delRes.status()).toBe(200);
+
+    // Confirm gone
+    const getRes = await request.get(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments/${attachment.id}`,
+      { headers: { Authorization: `Bearer ${doctorToken}` } }
+    );
+    expect(getRes.status()).toBe(404);
+  });
+
+  test("MR-ATT-A4: POST attachment returns 401 without auth", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        multipart: {
+          file: {
+            name: "test.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from("x"),
+          },
+        },
+      }
+    );
+    expect(res.status()).toBe(401);
+  });
+
+  test("MR-ATT-A5: POST attachment returns 403 for non-doctor (patient)", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${patientToken}` },
+        multipart: {
+          file: {
+            name: "test.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from("x"),
+          },
+        },
+      }
+    );
+    expect(res.status()).toBe(403);
+  });
+
+  test("MR-ATT-A6: POST attachment returns 404 for non-existent record", async ({
+    request,
+  }) => {
+    const fakeId = "00000000-0000-4000-8000-000000000000";
+    const res = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${fakeId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${doctorToken}` },
+        multipart: {
+          file: {
+            name: "test.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from("x"),
+          },
+        },
+      }
+    );
+    expect(res.status()).toBe(404);
+  });
+
+  test("MR-ATT-A7: DELETE attachment returns 403 for non-owning doctor", async ({
+    request,
+  }) => {
+    // Upload as the real doctor
+    const uploadRes = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${doctorToken}` },
+        multipart: {
+          file: {
+            name: "owned.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from("x"),
+          },
+        },
+      }
+    );
+    const attachment = await uploadRes.json();
+
+    // Create another doctor
+    const deptRes = await request.post(`${config.apiUrl}/api/v1/departments`, {
+      data: { name: `Other Dept ${faker.string.alphanumeric(6)}` },
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const otherDept = await deptRes.json();
+
+    const otherDocData = {
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      email: faker.internet.email().toLowerCase(),
+      password: "Password123!",
+    };
+    const otherDocRes = await request.post(`${config.apiUrl}/api/v1/doctors`, {
+      data: {
+        ...otherDocData,
+        departmentId: otherDept.id,
+        specialization: "Surgery",
+        licenseNumber: faker.string.alphanumeric(10).toUpperCase(),
+      },
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const otherDoc = await otherDocRes.json();
+
+    const otherLoginRes = await request.post(
+      `${config.apiUrl}/api/v1/auth/login`,
+      {
+        data: { email: otherDocData.email, password: otherDocData.password },
+      }
+    );
+    const otherToken = (await otherLoginRes.json()).accessToken;
+
+    // That other doctor tries to delete
+    const delRes = await request.delete(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments/${attachment.id}`,
+      { headers: { Authorization: `Bearer ${otherToken}` } }
+    );
+    expect(delRes.status()).toBe(403);
+  });
+
+  test("MR-ATT-A8: POST returns 400 for disallowed file type", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${doctorToken}` },
+        multipart: {
+          file: {
+            name: "malicious.exe",
+            mimeType: "application/x-executable",
+            buffer: Buffer.from("binary"),
+          },
+        },
+      }
+    );
+    expect(res.status()).toBe(400);
+  });
+
+  test("MR-ATT-A9: GET attachment returns 403 for unauthorized patient", async ({
+    request,
+  }) => {
+    // Create a second patient with no ties to this record
+    const otherPatientRes = await request.post(
+      `${config.apiUrl}/api/v1/auth/register`,
+      {
+        data: {
+          role: "patient",
+          email: faker.internet.email().toLowerCase(),
+          password: "Password123!",
+          firstName: faker.person.firstName(),
+          lastName: faker.person.lastName(),
+        },
+      }
+    );
+    const otherToken = (await otherPatientRes.json()).accessToken;
+
+    // Upload an attachment first
+    const uploadRes = await request.post(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments`,
+      {
+        headers: { Authorization: `Bearer ${doctorToken}` },
+        multipart: {
+          file: {
+            name: "secret.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from("secret"),
+          },
+        },
+      }
+    );
+    const attachment = await uploadRes.json();
+
+    // Other patient tries to GET it
+    const getRes = await request.get(
+      `${config.apiUrl}/api/v1/medical-records/${recordId}/attachments/${attachment.id}`,
+      { headers: { Authorization: `Bearer ${otherToken}` } }
+    );
+    expect(getRes.status()).toBe(403);
+  });
+});
+
 // ─── UI happy-path ────────────────────────────────────────────────────────────
 
 test.describe("Medical Records — UI happy-path", () => {

--- a/apps/web/src/components/attachments/attachment-list.tsx
+++ b/apps/web/src/components/attachments/attachment-list.tsx
@@ -1,0 +1,116 @@
+import { useState, useCallback } from "react";
+import { FileIcon, DownloadIcon, Trash2Icon, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { attachmentsApi } from "@/lib/attachments-api";
+import type { MedicalRecordAttachment } from "@caresync/shared";
+
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+function getFileIcon(fileType: string) {
+  return FileIcon;
+}
+
+interface Attachment {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  fileType: string;
+  fileSize: number;
+}
+
+interface AttachmentListProps {
+  attachments: Attachment[];
+  onDelete?: (attachmentId: string) => void;
+  showDownload?: boolean;
+  className?: string;
+}
+
+export function AttachmentList({
+  attachments,
+  onDelete,
+  showDownload = true,
+  className,
+}: AttachmentListProps) {
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const handleDownload = useCallback(async (attachment: Attachment) => {
+    setDownloadingId(attachment.id);
+    try {
+      const url = attachmentsApi.downloadUrl(attachment.fileUrl);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = attachment.fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } finally {
+      setDownloadingId(null);
+    }
+  }, []);
+
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <p className="text-sm font-medium text-foreground">Attachments</p>
+      <ul className="divide-y divide-border rounded-lg border border-border overflow-hidden">
+        {attachments.map((attachment) => {
+          const Icon = getFileIcon(attachment.fileType);
+          const isDownloading = downloadingId === attachment.id;
+
+          return (
+            <li
+              key={attachment.id}
+              className="flex items-center gap-3 px-3 py-2.5 bg-card hover:bg-accent/50 transition-colors"
+            >
+              <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-foreground truncate">
+                  {attachment.fileName}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {formatFileSize(attachment.fileSize)}
+                </p>
+              </div>
+              <div className="flex items-center gap-1 shrink-0">
+                {showDownload && (
+                  <button
+                    type="button"
+                    onClick={() => handleDownload(attachment)}
+                    disabled={isDownloading}
+                    className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+                    title="Download"
+                  >
+                    {isDownloading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <DownloadIcon className="h-4 w-4" />
+                    )}
+                  </button>
+                )}
+                {onDelete && (
+                  <button
+                    type="button"
+                    onClick={() => onDelete(attachment.id)}
+                    className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                    title="Delete"
+                  >
+                    <Trash2Icon className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/attachments/file-upload.tsx
+++ b/apps/web/src/components/attachments/file-upload.tsx
@@ -1,0 +1,226 @@
+import { useState, useCallback, useRef } from "react";
+import { UploadCloudIcon, XIcon, Loader2, FileIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface UploadingFile {
+  id: string;
+  file: File;
+  progress: number;
+  error?: string;
+}
+
+interface FileUploadProps {
+  onUpload: (file: File) => Promise<void>;
+  accept?: string;
+  maxSizeMB?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function FileUpload({
+  onUpload,
+  accept,
+  maxSizeMB = 10,
+  disabled = false,
+  className,
+}: FileUploadProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const validateFile = useCallback(
+    (file: File): string | null => {
+      const maxBytes = maxSizeMB * 1024 * 1024;
+      if (file.size > maxBytes) {
+        return `${file.name} exceeds ${maxSizeMB}MB limit`;
+      }
+      return null;
+    },
+    [maxSizeMB]
+  );
+
+  const addFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+
+      setValidationError(null);
+
+      // Validate all files first
+      const newUploadingFiles: UploadingFile[] = [];
+      for (const file of Array.from(files)) {
+        const error = validateFile(file);
+        newUploadingFiles.push({
+          id: `${file.name}-${Date.now()}-${Math.random()}`,
+          file,
+          progress: 0,
+          error: error ?? undefined,
+        });
+      }
+
+      setUploadingFiles((prev) => [...prev, ...newUploadingFiles]);
+
+      // Upload valid files
+      for (const uploadingFile of newUploadingFiles) {
+        if (!uploadingFile.error) {
+          try {
+            await onUpload(uploadingFile.file);
+            // Remove from uploading list on success
+            setUploadingFiles((prev) =>
+              prev.filter((f) => f.id !== uploadingFile.id)
+            );
+          } catch {
+            // Mark as error but keep in list so user can see
+            setUploadingFiles((prev) =>
+              prev.map((f) =>
+                f.id === uploadingFile.id
+                  ? { ...f, error: "Upload failed. Try again." }
+                  : f
+              )
+            );
+          }
+        }
+      }
+    },
+    [onUpload, validateFile]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      addFiles(e.dataTransfer.files);
+    },
+    [addFiles]
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      addFiles(e.target.files);
+      // Reset input so same file can be selected again
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+    },
+    [addFiles]
+  );
+
+  const removeFile = useCallback((id: string) => {
+    setUploadingFiles((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  const clearError = useCallback(() => {
+    setValidationError(null);
+  }, []);
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {/* Drop zone */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => !disabled && inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if ((e.key === "Enter" || e.key === " ") && !disabled) {
+            inputRef.current?.click();
+          }
+        }}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={cn(
+          "relative flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-6 cursor-pointer transition-colors",
+          isDragging
+            ? "border-primary bg-primary/5"
+            : "border-border hover:border-primary/50 hover:bg-accent/50",
+          disabled && "opacity-50 cursor-not-allowed pointer-events-none"
+        )}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept={accept}
+          onChange={handleInputChange}
+          disabled={disabled}
+          className="sr-only"
+          aria-label="File upload"
+        />
+        <UploadCloudIcon
+          className={cn(
+            "h-8 w-8",
+            isDragging ? "text-primary" : "text-muted-foreground"
+          )}
+        />
+        <div className="text-center">
+          <p className="text-sm font-medium text-foreground">
+            {isDragging ? "Drop files here" : "Drag & drop or click to browse"}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Maximum file size: {maxSizeMB}MB
+          </p>
+        </div>
+      </div>
+
+      {/* Validation error */}
+      {validationError && (
+        <div className="flex items-center gap-2 text-sm text-destructive">
+          <span>{validationError}</span>
+          <button
+            type="button"
+            onClick={clearError}
+            className="inline-flex items-center justify-center"
+          >
+            <XIcon className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Uploading files list */}
+      {uploadingFiles.length > 0 && (
+        <ul className="divide-y divide-border rounded-lg border border-border overflow-hidden">
+          {uploadingFiles.map((uploadingFile) => (
+            <li
+              key={uploadingFile.id}
+              className="flex items-center gap-3 px-3 py-2.5 bg-card"
+            >
+              <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-foreground truncate">
+                  {uploadingFile.file.name}
+                </p>
+                {uploadingFile.error ? (
+                  <p className="text-xs text-destructive">
+                    {uploadingFile.error}
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">Uploading...</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => removeFile(uploadingFile.id)}
+                className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+              >
+                <XIcon className="h-4 w-4" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/attachments/index.ts
+++ b/apps/web/src/components/attachments/index.ts
@@ -1,0 +1,2 @@
+export { AttachmentList } from "./attachment-list";
+export { FileUpload } from "./file-upload";

--- a/apps/web/src/lib/attachments-api.ts
+++ b/apps/web/src/lib/attachments-api.ts
@@ -1,0 +1,42 @@
+import { apiClient } from "./api-client";
+import type { MedicalRecordAttachment } from "@caresync/shared";
+
+export interface ListAttachmentsParams {
+  medicalRecordId: string;
+}
+
+export const attachmentsApi = {
+  list: async (medicalRecordId: string): Promise<MedicalRecordAttachment[]> => {
+    const res = await apiClient.get<MedicalRecordAttachment[]>(
+      `/api/v1/medical-records/${medicalRecordId}/attachments`
+    );
+    return res.data;
+  },
+
+  upload: async (
+    medicalRecordId: string,
+    file: File
+  ): Promise<MedicalRecordAttachment> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const res = await apiClient.post<MedicalRecordAttachment>(
+      `/api/v1/medical-records/${medicalRecordId}/attachments`,
+      formData,
+      {
+        headers: { "Content-Type": "multipart/form-data" },
+      }
+    );
+    return res.data;
+  },
+
+  delete: async (attachmentId: string): Promise<void> => {
+    await apiClient.delete(`/api/v1/attachments/${attachmentId}`);
+  },
+
+  downloadUrl: (fileUrl: string): string => {
+    // If it's already an absolute URL, return it
+    if (fileUrl.startsWith("http")) return fileUrl;
+    // Otherwise prepend the API base URL
+    return `/api/v1${fileUrl.startsWith("/") ? "" : "/"}${fileUrl}`;
+  },
+};

--- a/apps/web/src/pages/medical-records/detail.tsx
+++ b/apps/web/src/pages/medical-records/detail.tsx
@@ -1,7 +1,10 @@
 import { useLoaderData, Link } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
+import { useState, useCallback } from "react";
 import { medicalRecordsApi } from "@/lib/api-client";
-import type { MedicalRecord } from "@caresync/shared";
+import { attachmentsApi } from "@/lib/attachments-api";
+import type { MedicalRecord, MedicalRecordAttachment } from "@caresync/shared";
+import { AttachmentList, FileUpload } from "@/components/attachments";
 
 // ─── Loader ────────────────────────────────────────────────────────────────────
 
@@ -10,7 +13,9 @@ export async function medicalRecordDetailLoader({
 }: LoaderFunctionArgs) {
   const { id } = params;
   if (!id) throw new Response("Not found", { status: 404 });
-  return medicalRecordsApi.get(id);
+  const record = await medicalRecordsApi.get(id);
+  const attachments = await attachmentsApi.list(id);
+  return { record, attachments };
 }
 
 // ─── Detail row helper ─────────────────────────────────────────────────────────
@@ -35,11 +40,30 @@ function DetailRow({
 // ─── Page ──────────────────────────────────────────────────────────────────────
 
 export function MedicalRecordDetailPage() {
-  const record = useLoaderData() as MedicalRecord;
+  const { record, attachments: initialAttachments } = useLoaderData() as {
+    record: MedicalRecord;
+    attachments: MedicalRecordAttachment[];
+  };
+  const [attachments, setAttachments] = useState(initialAttachments);
 
   const doctorName = record.doctor
     ? `Dr. ${record.doctor.user.firstName} ${record.doctor.user.lastName}`
     : "—";
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      await attachmentsApi.upload(record.id, file);
+      // Refresh attachments list
+      const updated = await attachmentsApi.list(record.id);
+      setAttachments(updated);
+    },
+    [record.id]
+  );
+
+  const handleDelete = useCallback(async (attachmentId: string) => {
+    await attachmentsApi.delete(attachmentId);
+    setAttachments((prev) => prev.filter((a) => a.id !== attachmentId));
+  }, []);
 
   return (
     <div data-testid="medical-record-detail-page">
@@ -147,6 +171,21 @@ export function MedicalRecordDetailPage() {
             </dl>
           </div>
         )}
+
+        {/* Attachments */}
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h2 className="mb-4 text-base font-semibold text-foreground">
+            Attachments
+          </h2>
+          <div className="space-y-4">
+            <FileUpload
+              onUpload={handleUpload}
+              accept="image/*,.pdf,.doc,.docx,.txt"
+              maxSizeMB={10}
+            />
+            <AttachmentList attachments={attachments} onDelete={handleDelete} />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,578 @@
+{
+  "name": "caresync",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caresync",
+      "devDependencies": {
+        "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
+        "prettier": "^3.8.2",
+        "turbo": "^2"
+      }
+    },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.6.tgz",
+      "integrity": "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.6.tgz",
+      "integrity": "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.6.tgz",
+      "integrity": "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.6.tgz",
+      "integrity": "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.6.tgz",
+      "integrity": "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.6.tgz",
+      "integrity": "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/turbo": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.6.tgz",
+      "integrity": "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "@turbo/darwin-64": "2.9.6",
+        "@turbo/darwin-arm64": "2.9.6",
+        "@turbo/linux-64": "2.9.6",
+        "@turbo/linux-arm64": "2.9.6",
+        "@turbo/windows-64": "2.9.6",
+        "@turbo/windows-arm64": "2.9.6"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,9 +46,15 @@ importers:
       jsonwebtoken:
         specifier: ^9.0
         version: 9.0.3
+      multer:
+        specifier: ^1.4.5-lts.1
+        version: 1.4.5-lts.2
       pg:
         specifier: ^8.13
         version: 8.20.0
+      uuid:
+        specifier: ^11.0
+        version: 11.1.0
       zod:
         specifier: ^3.24
         version: 3.25.76
@@ -59,12 +65,18 @@ importers:
       "@types/jsonwebtoken":
         specifier: ^9.0
         version: 9.0.10
+      "@types/multer":
+        specifier: ^1.4
+        version: 1.4.13
       "@types/node":
         specifier: ^22
         version: 22.19.17
       "@types/pg":
         specifier: ^8.11
         version: 8.20.0
+      "@types/uuid":
+        specifier: ^10
+        version: 10.0.0
       drizzle-kit:
         specifier: ^0.30
         version: 0.30.6
@@ -2107,10 +2119,22 @@ packages:
         integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==,
       }
 
+  "@types/body-parser@1.19.6":
+    resolution:
+      {
+        integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==,
+      }
+
   "@types/chai@5.2.3":
     resolution:
       {
         integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
+
+  "@types/connect@3.4.38":
+    resolution:
+      {
+        integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==,
       }
 
   "@types/d3-array@3.2.2":
@@ -2185,6 +2209,24 @@ packages:
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
       }
 
+  "@types/express-serve-static-core@5.1.1":
+    resolution:
+      {
+        integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==,
+      }
+
+  "@types/express@5.0.6":
+    resolution:
+      {
+        integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==,
+      }
+
+  "@types/http-errors@2.0.5":
+    resolution:
+      {
+        integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==,
+      }
+
   "@types/json-schema@7.0.15":
     resolution:
       {
@@ -2203,6 +2245,12 @@ packages:
         integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
       }
 
+  "@types/multer@1.4.13":
+    resolution:
+      {
+        integrity: sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==,
+      }
+
   "@types/node@22.19.17":
     resolution:
       {
@@ -2213,6 +2261,18 @@ packages:
     resolution:
       {
         integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==,
+      }
+
+  "@types/qs@6.15.0":
+    resolution:
+      {
+        integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==,
+      }
+
+  "@types/range-parser@1.2.7":
+    resolution:
+      {
+        integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==,
       }
 
   "@types/react-dom@19.2.3":
@@ -2229,10 +2289,28 @@ packages:
         integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==,
       }
 
+  "@types/send@1.2.1":
+    resolution:
+      {
+        integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==,
+      }
+
+  "@types/serve-static@2.2.0":
+    resolution:
+      {
+        integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==,
+      }
+
   "@types/statuses@2.0.6":
     resolution:
       {
         integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==,
+      }
+
+  "@types/uuid@10.0.0":
+    resolution:
+      {
+        integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==,
       }
 
   "@typescript-eslint/eslint-plugin@8.58.2":
@@ -2453,6 +2531,12 @@ packages:
       }
     engines: { node: ">=12" }
 
+  append-field@1.0.0:
+    resolution:
+      {
+        integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==,
+      }
+
   aria-query@5.3.0:
     resolution:
       {
@@ -2538,6 +2622,13 @@ packages:
       {
         integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
       }
+
+  busboy@1.6.0:
+    resolution:
+      {
+        integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==,
+      }
+    engines: { node: ">=10.16.0" }
 
   call-bind-apply-helpers@1.0.2:
     resolution:
@@ -2633,6 +2724,13 @@ packages:
       }
     engines: { node: ">=20" }
 
+  concat-stream@1.6.2:
+    resolution:
+      {
+        integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==,
+      }
+    engines: { "0": node >= 0.8 }
+
   convert-source-map@2.0.0:
     resolution:
       {
@@ -2645,6 +2743,12 @@ packages:
         integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==,
       }
     engines: { node: ">=18" }
+
+  core-util-is@1.0.3:
+    resolution:
+      {
+        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
+      }
 
   cross-spawn@7.0.6:
     resolution:
@@ -3432,6 +3536,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  inherits@2.0.4:
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
+
   internmap@2.0.3:
     resolution:
       {
@@ -3477,6 +3587,12 @@ packages:
     resolution:
       {
         integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==,
+      }
+
+  isarray@1.0.0:
+    resolution:
+      {
+        integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==,
       }
 
   isexe@2.0.0:
@@ -3820,6 +3936,13 @@ packages:
         integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
 
+  media-typer@0.3.0:
+    resolution:
+      {
+        integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==,
+      }
+    engines: { node: ">= 0.6" }
+
   mime-db@1.52.0:
     resolution:
       {
@@ -3855,6 +3978,19 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
+  minimist@1.2.8:
+    resolution:
+      {
+        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
+
+  mkdirp@0.5.6:
+    resolution:
+      {
+        integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==,
+      }
+    hasBin: true
+
   ms@2.1.3:
     resolution:
       {
@@ -3873,6 +4009,14 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  multer@1.4.5-lts.2:
+    resolution:
+      {
+        integrity: sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==,
+      }
+    engines: { node: ">= 6.0.0" }
+    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   mute-stream@2.0.0:
     resolution:
@@ -4130,6 +4274,12 @@ packages:
       }
     engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
 
+  process-nextick-args@2.0.1:
+    resolution:
+      {
+        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
+      }
+
   prop-types@15.8.1:
     resolution:
       {
@@ -4230,6 +4380,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  readable-stream@2.3.8:
+    resolution:
+      {
+        integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==,
+      }
+
   recharts-scale@0.4.5:
     resolution:
       {
@@ -4299,6 +4455,12 @@ packages:
       }
     engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
+
+  safe-buffer@5.1.2:
+    resolution:
+      {
+        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
+      }
 
   safe-buffer@5.2.1:
     resolution:
@@ -4443,6 +4605,13 @@ packages:
         integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==,
       }
 
+  streamsearch@1.1.0:
+    resolution:
+      {
+        integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==,
+      }
+    engines: { node: ">=10.0.0" }
+
   strict-event-emitter@0.5.1:
     resolution:
       {
@@ -4476,6 +4645,12 @@ packages:
         integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==,
       }
     engines: { node: ">=20" }
+
+  string_decoder@1.1.1:
+    resolution:
+      {
+        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
+      }
 
   strip-ansi@6.0.1:
     resolution:
@@ -4628,6 +4803,19 @@ packages:
       }
     engines: { node: ">=20" }
 
+  type-is@1.6.18:
+    resolution:
+      {
+        integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==,
+      }
+    engines: { node: ">= 0.6" }
+
+  typedarray@0.0.6:
+    resolution:
+      {
+        integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==,
+      }
+
   typescript-eslint@8.58.2:
     resolution:
       {
@@ -4679,6 +4867,19 @@ packages:
       {
         integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
       }
+
+  util-deprecate@1.0.2:
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
+
+  uuid@11.1.0:
+    resolution:
+      {
+        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
+      }
+    hasBin: true
 
   victory-vendor@36.9.2:
     resolution:
@@ -5805,10 +6006,19 @@ snapshots:
 
   "@types/bcryptjs@2.4.6": {}
 
+  "@types/body-parser@1.19.6":
+    dependencies:
+      "@types/connect": 3.4.38
+      "@types/node": 22.19.17
+
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
       assertion-error: 2.0.1
+
+  "@types/connect@3.4.38":
+    dependencies:
+      "@types/node": 22.19.17
 
   "@types/d3-array@3.2.2": {}
 
@@ -5840,6 +6050,21 @@ snapshots:
 
   "@types/estree@1.0.8": {}
 
+  "@types/express-serve-static-core@5.1.1":
+    dependencies:
+      "@types/node": 22.19.17
+      "@types/qs": 6.15.0
+      "@types/range-parser": 1.2.7
+      "@types/send": 1.2.1
+
+  "@types/express@5.0.6":
+    dependencies:
+      "@types/body-parser": 1.19.6
+      "@types/express-serve-static-core": 5.1.1
+      "@types/serve-static": 2.2.0
+
+  "@types/http-errors@2.0.5": {}
+
   "@types/json-schema@7.0.15": {}
 
   "@types/jsonwebtoken@9.0.10":
@@ -5848,6 +6073,10 @@ snapshots:
       "@types/node": 22.19.17
 
   "@types/ms@2.1.0": {}
+
+  "@types/multer@1.4.13":
+    dependencies:
+      "@types/express": 5.0.6
 
   "@types/node@22.19.17":
     dependencies:
@@ -5859,6 +6088,10 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
+  "@types/qs@6.15.0": {}
+
+  "@types/range-parser@1.2.7": {}
+
   "@types/react-dom@19.2.3(@types/react@19.2.14)":
     dependencies:
       "@types/react": 19.2.14
@@ -5867,7 +6100,18 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  "@types/send@1.2.1":
+    dependencies:
+      "@types/node": 22.19.17
+
+  "@types/serve-static@2.2.0":
+    dependencies:
+      "@types/http-errors": 2.0.5
+      "@types/node": 22.19.17
+
   "@types/statuses@2.0.6": {}
+
+  "@types/uuid@10.0.0": {}
 
   "@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)":
     dependencies:
@@ -6048,6 +6292,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  append-field@1.0.0: {}
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -6091,6 +6337,10 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6138,9 +6388,18 @@ snapshots:
 
   commander@14.0.3: {}
 
+  concat-stream@1.6.2:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      typedarray: 0.0.6
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  core-util-is@1.0.3: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6611,6 +6870,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inherits@2.0.4: {}
+
   internmap@2.0.3: {}
 
   is-extglob@2.1.1: {}
@@ -6628,6 +6889,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -6825,6 +7088,8 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@0.3.0: {}
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -6838,6 +7103,12 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
 
   ms@2.1.3: {}
 
@@ -6865,6 +7136,16 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - "@types/node"
+
+  multer@1.4.5-lts.2:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 1.6.2
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
 
   mute-stream@2.0.0: {}
 
@@ -6990,6 +7271,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7043,6 +7326,16 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   recharts-scale@0.4.5:
     dependencies:
@@ -7112,6 +7405,8 @@ snapshots:
       "@rollup/rollup-win32-x64-msvc": 4.60.1
       fsevents: 2.3.3
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   saxes@6.0.0:
@@ -7170,6 +7465,8 @@ snapshots:
 
   std-env@4.0.0: {}
 
+  streamsearch@1.1.0: {}
+
   strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
@@ -7190,6 +7487,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:
@@ -7268,6 +7569,13 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typedarray@0.0.6: {}
+
   typescript-eslint@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       "@typescript-eslint/eslint-plugin": 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
@@ -7296,6 +7604,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  uuid@11.1.0: {}
 
   victory-vendor@36.9.2:
     dependencies:


### PR DESCRIPTION
## Summary
File attachment upload for medical records (Issue #18).

## Changes
- **Backend**: multer file upload, MIME type + size validation (10MB max)
- **API**: 
- **Frontend**: drag-and-drop upload zone + attachment list with download links
- **Tests**: 9 E2E tests for attachment API flows

## Files
```
apps/api/src/lib/file-storage.ts       # File storage utilities
apps/api/src/lib/upload.ts             # Multer middleware
apps/api/src/routes/attachments.ts     # Attachment CRUD endpoints
apps/api/src/lib/env.ts                # UPLOAD_DIR, MAX_FILE_SIZE
apps/web/src/lib/attachments-api.ts    # API client
apps/web/src/components/attachments/   # FileUpload + AttachmentList
apps/web/src/pages/medical-records/detail.tsx  # Integrated
apps/e2e/tests/medical-records.spec.ts # 9 new attachment tests
```
