### PR TITLE
feat(reviews): patient reviews after completed appointments

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import { patientsRoute } from "./routes/patients";
 import { appointmentsRoute } from "./routes/appointments";
 import { medicalRecordsRoute } from "./routes/medical-records";
 import { invoicesRoute } from "./routes/invoices";
+import { reviewsRoute } from "./routes/reviews";
 
 export type AppEnv = {
   Variables: {
@@ -50,6 +51,7 @@ app.route("/api/v1", patientsRoute);
 app.route("/api/v1", appointmentsRoute);
 app.route("/api/v1", medicalRecordsRoute);
 app.route("/api/v1", invoicesRoute);
+app.route("/api/v1", reviewsRoute);
 
 // OpenAPI spec
 app.doc("/api/openapi.json", {

--- a/apps/api/src/routes/doctors.test.ts
+++ b/apps/api/src/routes/doctors.test.ts
@@ -41,9 +41,11 @@ const mockDoctor = {
 
 // ─── Mock chain helpers ────────────────────────────────────────────────────────
 
-function makeSelectChain(result: unknown[]) {
+function makeSelectChain(result: unknown[], opts?: { countQuery?: boolean }) {
   const limit = vi.fn().mockResolvedValue(result);
-  const where = vi.fn().mockReturnValue({ limit });
+  const where = opts?.countQuery
+    ? vi.fn().mockResolvedValue(result)
+    : vi.fn().mockReturnValue({ limit });
   const innerJoin = vi.fn().mockReturnValue({
     innerJoin: vi.fn().mockReturnValue({ where, limit }),
     where,
@@ -126,12 +128,21 @@ describe("GET /doctors", () => {
 // ─── GET /doctors/:id ──────────────────────────────────────────────────────────
 
 describe("GET /doctors/:id", () => {
-  beforeEach(() => vi.resetAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db.select as any).mockReset();
+  });
 
   it("returns 200 with doctor for anyone", async () => {
-    vi.mocked(db.select).mockReturnValueOnce(
-      makeSelectChain([mockDoctor]) as any
-    );
+    // Use mockImplementationOnce per-call to avoid queue interference from other test files
+    (db.select as any)
+      .mockImplementationOnce(() => makeSelectChain([mockDoctor]) as any) // doctor query
+      .mockImplementationOnce(
+        () =>
+          makeSelectChain([{ averageRating: 4.5, reviewCount: 10 }], {
+            countQuery: true,
+          }) as any
+      ); // stats query
 
     const res = await app.request(
       `${BASE}/00000000-0000-0000-0000-000000000001`
@@ -141,6 +152,8 @@ describe("GET /doctors/:id", () => {
     const body = await res.json();
     expect(body.id).toBe("00000000-0000-0000-0000-000000000001");
     expect(body.user.lastName).toBe("Smith");
+    expect(body.averageRating).toBe(4.5);
+    expect(body.reviewCount).toBe(10);
   });
 
   it("returns 404 when doctor does not exist", async () => {

--- a/apps/api/src/routes/doctors.ts
+++ b/apps/api/src/routes/doctors.ts
@@ -1,5 +1,16 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { eq, ilike, or, sql, and, asc, inArray } from "drizzle-orm";
+import {
+  eq,
+  ilike,
+  or,
+  sql,
+  and,
+  asc,
+  inArray,
+  avg,
+  count,
+  desc,
+} from "drizzle-orm";
 import { db } from "../db";
 import {
   users,
@@ -8,6 +19,8 @@ import {
   appointments,
   medicalRecords,
   doctorSchedules,
+  reviews,
+  patients,
 } from "../db/schema";
 import { requireAuth, requireRole } from "../middleware/auth";
 import { hashPassword } from "../lib/password";
@@ -42,6 +55,8 @@ const doctorResponse = z.object({
   licenseNumber: z.string(),
   user: userResponse.optional(),
   department: departmentResponse.optional(),
+  averageRating: z.number().nullable().optional(),
+  reviewCount: z.number().nullable().optional(),
 });
 
 const errorResponse = z.object({ message: z.string() });
@@ -225,7 +240,126 @@ doctorsRoute.openapi(getDoctorRoute, async (c) => {
     return c.json({ message: "Doctor not found" }, 404);
   }
 
-  return c.json(doctor, 200);
+  const [stats] = await db
+    .select({
+      averageRating: sql<number | null>`avg(rating)::float`,
+      reviewCount: count(reviews.id),
+    })
+    .from(reviews)
+    .where(eq(reviews.doctorId, id));
+
+  return c.json(
+    {
+      ...doctor,
+      averageRating: stats?.averageRating ?? null,
+      reviewCount: Number(stats?.reviewCount) ?? 0,
+    },
+    200
+  );
+});
+
+// ─── GET /doctors/:id/reviews ────────────────────────────────────────────────
+
+const getDoctorReviewsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1).openapi({ example: 1 }),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(5)
+    .openapi({ example: 5 }),
+});
+
+const doctorReviewItem = z.object({
+  id: z.string(),
+  appointmentId: z.string(),
+  doctorId: z.string(),
+  rating: z.number(),
+  comment: z.string().nullable(),
+  createdAt: z.string(),
+  patientFirstName: z.string(),
+  patientLastName: z.string(),
+});
+
+const paginatedDoctorReviewsResponse = z.object({
+  data: z.array(doctorReviewItem),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+});
+
+const getDoctorReviewsRoute = createRoute({
+  method: "get",
+  path: "/doctors/{id}/reviews",
+  tags: ["Doctors"],
+  summary: "Get paginated reviews for a doctor",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth] as const,
+  request: {
+    params: z.object({ id: z.string() }),
+    query: getDoctorReviewsQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Paginated doctor reviews",
+      content: {
+        "application/json": { schema: paginatedDoctorReviewsResponse },
+      },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+doctorsRoute.openapi(getDoctorReviewsRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const { page, limit } = c.req.valid("query");
+  const offset = (page - 1) * limit;
+
+  const [countRow] = await db
+    .select({ count: count(reviews.id) })
+    .from(reviews)
+    .where(eq(reviews.doctorId, id));
+
+  const total = countRow?.count ?? 0;
+
+  const rows = await db
+    .select({
+      id: reviews.id,
+      appointmentId: reviews.appointmentId,
+      doctorId: reviews.doctorId,
+      rating: reviews.rating,
+      comment: reviews.comment,
+      createdAt: reviews.createdAt,
+      patientFirstName: users.firstName,
+      patientLastName: users.lastName,
+    })
+    .from(reviews)
+    .innerJoin(patients, eq(reviews.patientId, patients.id))
+    .innerJoin(users, eq(patients.userId, users.id))
+    .where(eq(reviews.doctorId, id))
+    .orderBy(desc(reviews.createdAt))
+    .offset(offset)
+    .limit(limit);
+
+  return c.json(
+    {
+      data: rows,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    },
+    200
+  );
 });
 
 // ─── POST /doctors (admin) ───────────────────────────────────────────────────

--- a/apps/api/src/routes/reviews.test.ts
+++ b/apps/api/src/routes/reviews.test.ts
@@ -1,0 +1,555 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { app } from "../app";
+import { signAccessToken } from "../lib/jwt";
+
+vi.mock("../db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+import { db } from "../db";
+
+const REVIEWS_URL = "/api/v1/reviews";
+
+const patientToken = signAccessToken({
+  userId: "a1b2c3d4-0000-4000-8000-000000000001",
+  role: "patient",
+});
+const doctorToken = signAccessToken({
+  userId: "a1b2c3d4-0000-4000-8000-000000000002",
+  role: "doctor",
+});
+const adminToken = signAccessToken({
+  userId: "a1b2c3d4-0000-4000-8000-000000000003",
+  role: "admin",
+});
+
+function bearer(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+const jsonHeaders = { "Content-Type": "application/json" };
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PATIENT_ID = "a1b2c3d4-0000-4000-8000-000000000010";
+const DOCTOR_ID = "a1b2c3d4-0000-4000-8000-000000000011";
+const APPT_ID = "a1b2c3d4-0000-4000-8000-000000000012";
+const REVIEW_ID = "a1b2c3d4-0000-4000-8000-000000000013";
+
+const mockAppointmentCompleted = {
+  id: APPT_ID,
+  patientId: PATIENT_ID,
+  doctorId: DOCTOR_ID,
+  appointmentDate: "2026-01-15",
+  startTime: "09:00:00",
+  endTime: "09:30:00",
+  status: "completed",
+  type: "consultation",
+  reason: null,
+  notes: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const mockAppointmentPending = {
+  ...mockAppointmentCompleted,
+  id: "a1b2c3d4-0000-4000-8000-000000000014",
+  status: "pending",
+};
+
+const mockReview = {
+  id: REVIEW_ID,
+  appointmentId: APPT_ID,
+  patientId: PATIENT_ID,
+  doctorId: DOCTOR_ID,
+  rating: 5,
+  comment: "Great doctor!",
+  createdAt: new Date().toISOString(),
+};
+
+// ─── Mock chain helpers ────────────────────────────────────────────────────────
+
+type MockChain = {
+  from: ReturnType<typeof vi.fn>;
+  innerJoin?: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit?: ReturnType<typeof vi.fn>;
+  orderBy?: ReturnType<typeof vi.fn>;
+  offset?: ReturnType<typeof vi.fn>;
+};
+
+// Build a query-builder mock chain for drizzle.
+// The actual chain is: db.select().from().innerJoin()? .where().orderBy()? .offset().limit()
+function buildChain(
+  result: unknown[],
+  opts: {
+    withInnerJoin?: boolean;
+    withOrderBy?: boolean;
+    withOffset?: boolean;
+    countQuery?: boolean;
+  } = {}
+): MockChain {
+  const { withInnerJoin, withOrderBy, withOffset } = opts;
+
+  if (opts.countQuery) {
+    // Count query: db.select({ count }).from(reviews).where()
+    // await db.select().from().where() returns [{ count: N }]
+    const where = vi.fn().mockResolvedValue(result);
+    const from = vi.fn().mockReturnValue({ where } as MockChain);
+    return { from, where } as MockChain;
+  }
+
+  // Normal query chain
+  // Self-referential: every chainable method returns the same chain object,
+  // so the code can call .innerJoin().innerJoin().where().limit() in sequence.
+  const chain = {
+    from: undefined as any,
+    innerJoin: undefined as any,
+    where: undefined as any,
+    limit: undefined as any,
+    orderBy: undefined as any,
+    offset: undefined as any,
+  };
+
+  // Set each method to return the same chain (self-referential)
+  chain.from = vi.fn().mockReturnValue(chain);
+  chain.innerJoin = vi.fn().mockReturnValue(chain);
+  chain.where = vi.fn().mockReturnValue(chain);
+  chain.limit = vi.fn().mockResolvedValue(result);
+  chain.orderBy = vi.fn().mockReturnValue(chain);
+  chain.offset = vi.fn().mockReturnValue(chain);
+
+  // Override specific behavior based on options
+  if (!withInnerJoin) {
+    chain.from = vi.fn().mockReturnValue({
+      innerJoin: chain.innerJoin,
+      where: chain.where,
+      limit: chain.limit,
+      orderBy: chain.orderBy,
+      offset: chain.offset,
+    });
+  }
+
+  return chain;
+}
+
+// Helper to set up db.select with sequential calls
+function setupSelectChains(...chains: MockChain[]) {
+  let callCount = 0;
+  (db.select as any).mockImplementation(() => {
+    if (callCount < chains.length) {
+      return chains[callCount++];
+    }
+    // Fallback — return a harmless chain
+    return buildChain([]);
+  });
+}
+
+// ─── POST /reviews ─────────────────────────────────────────────────────────────
+
+describe("POST /reviews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset to undefined to clear both mockReturnValueOnce queue AND mockImplementation queue
+    (db.insert as any).mockReset();
+    (db.select as any).mockReset();
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 5 }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when called by doctor", async () => {
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(doctorToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 5 }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when called by admin", async () => {
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(adminToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 5 }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when appointmentId is missing", async () => {
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ rating: 5 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when rating is missing", async () => {
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when rating is out of range (< 1)", async () => {
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 0 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when rating is out of range (> 5)", async () => {
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 6 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when comment exceeds 500 characters", async () => {
+    const longComment = "a".repeat(501);
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({
+        appointmentId: APPT_ID,
+        rating: 5,
+        comment: longComment,
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when appointment does not exist", async () => {
+    // Appointment lookup: innerJoin chain returning empty
+    setupSelectChains(buildChain([], { withInnerJoin: true }));
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 5 }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.message).toBe("Appointment not found");
+  });
+
+  it("returns 403 when patient does not own the appointment", async () => {
+    setupSelectChains(
+      buildChain(
+        [
+          {
+            appointment: {
+              ...mockAppointmentCompleted,
+              patientId: "different-patient",
+            },
+            patientUserId: "different-user",
+          },
+        ],
+        { withInnerJoin: true }
+      )
+    );
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 5 }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.message).toBe("You can only review your own appointments");
+  });
+
+  it("returns 403 when appointment is not completed", async () => {
+    setupSelectChains(
+      buildChain(
+        [
+          {
+            appointment: mockAppointmentPending,
+            patientUserId: "a1b2c3d4-0000-4000-8000-000000000001",
+          },
+        ],
+        { withInnerJoin: true }
+      )
+    );
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 5 }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.message).toBe("Only completed appointments can be reviewed");
+  });
+
+  it("returns 400 when a review already exists for this appointment", async () => {
+    // First call: appointment lookup (completed, owned by patient)
+    // Second call: existing review check
+    setupSelectChains(
+      buildChain(
+        [
+          {
+            appointment: mockAppointmentCompleted,
+            patientUserId: "a1b2c3d4-0000-4000-8000-000000000001",
+          },
+        ],
+        { withInnerJoin: true }
+      ),
+      buildChain([mockReview])
+    );
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 5 }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toBe("You have already reviewed this appointment");
+  });
+
+  it("returns 201 and creates the review with comment", async () => {
+    // Setup db.select chains: (1) appt join, (2) no existing review
+    (db.select as any).mockImplementationOnce(() =>
+      buildChain(
+        [
+          {
+            appointment: mockAppointmentCompleted,
+            patientUserId: "a1b2c3d4-0000-4000-8000-000000000001",
+          },
+        ],
+        { withInnerJoin: true }
+      )
+    );
+    (db.select as any).mockImplementationOnce(() => buildChain([]));
+
+    // Setup db.insert — use mockReturnValueOnce with plain arrow functions.
+    // Plain functions avoid any vi.fn() state issues between tests.
+    (db.insert as any).mockReturnValueOnce({
+      values: () => ({
+        returning: () => Promise.resolve([mockReview]),
+      }),
+    });
+
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({
+        appointmentId: APPT_ID,
+        rating: 5,
+        comment: "Great doctor!",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBe(REVIEW_ID);
+    expect(body.rating).toBe(5);
+    expect(body.comment).toBe("Great doctor!");
+  });
+
+  it("returns 201 and creates the review without comment", async () => {
+    const reviewNoComment = {
+      ...mockReview,
+      id: REVIEW_ID,
+      appointmentId: APPT_ID,
+      patientId: PATIENT_ID,
+      doctorId: DOCTOR_ID,
+      rating: 4,
+      comment: null,
+    };
+    (db.select as any).mockImplementationOnce(() =>
+      buildChain(
+        [
+          {
+            appointment: mockAppointmentCompleted,
+            patientUserId: "a1b2c3d4-0000-4000-8000-000000000001",
+          },
+        ],
+        { withInnerJoin: true }
+      )
+    );
+    (db.select as any).mockImplementationOnce(() => buildChain([]));
+
+    // Use mockReturnValueOnce with plain arrow functions — reset clears the queue
+    (db.insert as any).mockReturnValueOnce({
+      values: () => ({
+        returning: () => Promise.resolve([reviewNoComment]),
+      }),
+    });
+
+    const res = await app.request(REVIEWS_URL, {
+      method: "POST",
+      headers: { ...jsonHeaders, ...bearer(patientToken) },
+      body: JSON.stringify({ appointmentId: APPT_ID, rating: 4 }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.rating).toBe(4);
+    expect(body.comment).toBeNull();
+  });
+});
+
+// ─── GET /reviews/appointment/:appointmentId ─────────────────────────────────
+
+describe("GET /reviews/appointment/:appointmentId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db.select as any).mockReset();
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await app.request(`${REVIEWS_URL}/appointment/${APPT_ID}`, {
+      method: "GET",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when no review exists for the appointment", async () => {
+    setupSelectChains(buildChain([]));
+    const res = await app.request(`${REVIEWS_URL}/appointment/${APPT_ID}`, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with the review when it exists", async () => {
+    setupSelectChains(buildChain([mockReview]));
+    const res = await app.request(`${REVIEWS_URL}/appointment/${APPT_ID}`, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(REVIEW_ID);
+    expect(body.rating).toBe(5);
+    expect(body.comment).toBe("Great doctor!");
+  });
+});
+
+// ─── GET /doctors/:id/reviews ─────────────────────────────────────────────────
+
+describe("GET /doctors/:id/reviews", () => {
+  const DOCTOR_ID = "a1b2c3d4-0000-4000-8000-000000000011";
+  const REVIEWS_URL_DOC = `/api/v1/doctors/${DOCTOR_ID}/reviews`;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db.select as any).mockReset();
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await app.request(REVIEWS_URL_DOC, { method: "GET" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with paginated reviews for a doctor", async () => {
+    const mockReviewRow = {
+      ...mockReview,
+      patientFirstName: "John",
+      patientLastName: "Doe",
+    };
+    // Count query chain: db.select().from().where() (no .limit())
+    const countChain = buildChain([{ count: 1 }], { countQuery: true });
+    // Data query chain: db.select().from().innerJoin().innerJoin().where().orderBy().offset().limit()
+    const dataChain = buildChain([mockReviewRow], {
+      withInnerJoin: true,
+      withOrderBy: true,
+      withOffset: true,
+    });
+
+    (db.select as any)
+      .mockImplementationOnce(() => countChain)
+      .mockImplementationOnce(() => dataChain);
+
+    const res = await app.request(REVIEWS_URL_DOC, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.total).toBe(1);
+    expect(body.page).toBe(1);
+    expect(body.totalPages).toBe(1);
+    expect(body.data[0].rating).toBe(5);
+    expect(body.data[0].patientFirstName).toBe("John");
+  });
+
+  it("returns empty data array when doctor has no reviews", async () => {
+    const countChain = buildChain([{ count: 0 }], { countQuery: true });
+    const dataChain = buildChain([], {
+      withInnerJoin: true,
+      withOrderBy: true,
+      withOffset: true,
+    });
+
+    (db.select as any)
+      .mockImplementationOnce(() => countChain)
+      .mockImplementationOnce(() => dataChain);
+
+    const res = await app.request(REVIEWS_URL_DOC, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(0);
+    expect(body.total).toBe(0);
+  });
+
+  it("respects page and limit params", async () => {
+    const countChain = buildChain([{ count: 25 }], { countQuery: true });
+    const dataChain = buildChain([mockReview], {
+      withInnerJoin: true,
+      withOrderBy: true,
+      withOffset: true,
+    });
+
+    (db.select as any)
+      .mockImplementationOnce(() => countChain)
+      .mockImplementationOnce(() => dataChain);
+
+    const res = await app.request(`${REVIEWS_URL_DOC}?page=2&limit=10`, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.page).toBe(2);
+    expect(body.limit).toBe(10);
+    expect(body.totalPages).toBe(3);
+  });
+
+  it("orders reviews by createdAt descending (newest first)", async () => {
+    const countChain = buildChain([{ count: 2 }], { countQuery: true });
+    const dataChain = buildChain([mockReview], {
+      withInnerJoin: true,
+      withOrderBy: true,
+      withOffset: true,
+    });
+
+    (db.select as any)
+      .mockImplementationOnce(() => countChain)
+      .mockImplementationOnce(() => dataChain);
+
+    const res = await app.request(REVIEWS_URL_DOC, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(200);
+    expect(db.select).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/reviews.ts
+++ b/apps/api/src/routes/reviews.ts
@@ -1,0 +1,185 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { reviews, appointments, patients } from "../db/schema";
+import { requireAuth, requireRole } from "../middleware/auth";
+import type { AppEnv } from "../app";
+
+export const reviewsRoute = new OpenAPIHono<AppEnv>();
+
+const errorResponse = z.object({ message: z.string() });
+
+// ─── Shared schemas ────────────────────────────────────────────────────────────
+
+const reviewResponse = z.object({
+  id: z.string(),
+  appointmentId: z.string(),
+  patientId: z.string(),
+  doctorId: z.string(),
+  rating: z.number(),
+  comment: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const createReviewBody = z.object({
+  appointmentId: z.string().uuid(),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(500).optional().nullable(),
+});
+
+const createReviewRoute = createRoute({
+  method: "post",
+  path: "/reviews",
+  tags: ["Reviews"],
+  summary: "Submit a review for a completed appointment",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth, requireRole("patient")] as const,
+  request: {
+    body: {
+      content: { "application/json": { schema: createReviewBody } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      description: "Review created",
+      content: { "application/json": { schema: reviewResponse } },
+    },
+    400: {
+      description: "Validation error or already reviewed",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Not your appointment or not completed",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Appointment not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+reviewsRoute.openapi(createReviewRoute, async (c) => {
+  const { appointmentId, rating, comment } = c.req.valid("json");
+  const userId = c.get("userId");
+
+  // 1. Fetch appointment with patient userId in one join query
+  const [row] = await db
+    .select({
+      appointment: appointments,
+      patientUserId: patients.userId,
+    })
+    .from(appointments)
+    .innerJoin(patients, eq(appointments.patientId, patients.id))
+    .where(eq(appointments.id, appointmentId))
+    .limit(1);
+
+  if (!row) {
+    return c.json({ message: "Appointment not found" }, 404);
+  }
+
+  const { appointment } = row;
+
+  // 2. Check ownership via userId
+  if (row.patientUserId !== userId) {
+    return c.json(
+      { message: "You can only review your own appointments" },
+      403
+    );
+  }
+
+  // 3. Check appointment is completed
+  if (appointment.status !== "completed") {
+    return c.json(
+      { message: "Only completed appointments can be reviewed" },
+      403
+    );
+  }
+
+  // 4. Check no existing review
+  const [existingReview] = await db
+    .select()
+    .from(reviews)
+    .where(eq(reviews.appointmentId, appointmentId))
+    .limit(1);
+
+  if (existingReview) {
+    return c.json(
+      { message: "You have already reviewed this appointment" },
+      400
+    );
+  }
+
+  // 5. Create the review
+  const [created] = await db
+    .insert(reviews)
+    .values({
+      appointmentId,
+      patientId: appointment.patientId,
+      doctorId: appointment.doctorId,
+      rating,
+      comment: comment ?? null,
+    })
+    .returning();
+
+  return c.json(
+    {
+      ...created,
+      createdAt: new Date(created.createdAt).toISOString(),
+    },
+    201
+  );
+});
+
+// ─── GET /reviews/appointment/:appointmentId ───────────────────────────────────
+
+const getReviewByAppointmentRoute = createRoute({
+  method: "get",
+  path: "/reviews/appointment/{appointmentId}",
+  tags: ["Reviews"],
+  summary: "Get review for an appointment",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth] as const,
+  request: { params: z.object({ appointmentId: z.string().uuid() }) },
+  responses: {
+    200: {
+      description: "Review for the appointment",
+      content: { "application/json": { schema: reviewResponse } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Review not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+reviewsRoute.openapi(getReviewByAppointmentRoute, async (c) => {
+  const { appointmentId } = c.req.valid("param");
+
+  const [review] = await db
+    .select()
+    .from(reviews)
+    .where(eq(reviews.appointmentId, appointmentId))
+    .limit(1);
+
+  if (!review) {
+    return c.json({ message: "Review not found" }, 404);
+  }
+
+  return c.json(
+    {
+      ...review,
+      createdAt: new Date(review.createdAt).toISOString(),
+    },
+    200
+  );
+});

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -13,6 +13,9 @@ import type {
   MedicalRecord,
   MedicalRecordAttachment,
   Invoice,
+  Review,
+  DoctorReview,
+  PaginatedDoctorReviewsResponse,
 } from "@caresync/shared";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -420,6 +423,42 @@ export const medicalRecordsApi = {
       `/api/v1/medical-records/${recordId}/attachments`,
       formData,
       { headers: { "Content-Type": "multipart/form-data" } }
+    );
+    return res.data;
+  },
+};
+
+// ─── Reviews API ─────────────────────────────────────────────────────────────
+
+export interface CreateReviewInput {
+  appointmentId: string;
+  rating: number;
+  comment?: string | null;
+}
+
+export const reviewsApi = {
+  /** POST /api/v1/reviews */
+  create: async (data: CreateReviewInput): Promise<Review> => {
+    const res = await apiClient.post<Review>("/api/v1/reviews", data);
+    return res.data;
+  },
+
+  /** GET /api/v1/reviews/appointment/:appointmentId */
+  getByAppointment: async (appointmentId: string): Promise<Review> => {
+    const res = await apiClient.get<Review>(
+      `/api/v1/reviews/appointment/${appointmentId}`
+    );
+    return res.data;
+  },
+
+  /** GET /api/v1/doctors/:id/reviews */
+  getByDoctor: async (
+    doctorId: string,
+    params?: { page?: number; limit?: number }
+  ): Promise<PaginatedDoctorReviewsResponse> => {
+    const res = await apiClient.get<PaginatedDoctorReviewsResponse>(
+      `/api/v1/doctors/${doctorId}/reviews`,
+      { params }
     );
     return res.data;
   },

--- a/apps/web/src/pages/appointments/detail.tsx
+++ b/apps/web/src/pages/appointments/detail.tsx
@@ -1,12 +1,17 @@
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useParams, Link, useLoaderData } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
-import { appointmentsApi, medicalRecordsApi } from "@/lib/api-client";
+import {
+  appointmentsApi,
+  medicalRecordsApi,
+  reviewsApi,
+} from "@/lib/api-client";
 import { useAuthStore } from "@/stores/auth-store";
 import type {
   Appointment,
   AppointmentStatus,
   MedicalRecord,
+  Review,
 } from "@caresync/shared";
 import { StatusBadge } from "./components/StatusBadge";
 
@@ -256,6 +261,206 @@ function MedicalRecordSection({
   );
 }
 
+// ─── Star Picker ─────────────────────────────────────────────────────────────
+
+interface StarPickerProps {
+  value: number;
+  onChange: (v: number) => void;
+  disabled?: boolean;
+}
+
+function StarPicker({ value, onChange, disabled }: StarPickerProps) {
+  return (
+    <div className="flex gap-1" data-testid="star-picker">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <button
+          key={star}
+          type="button"
+          data-testid={`star-${star}`}
+          disabled={disabled}
+          onClick={() => onChange(star)}
+          className={`text-2xl transition-colors ${disabled ? "cursor-default" : "cursor-pointer hover:scale-110"}`}
+        >
+          {star <= value ? (
+            <span className="text-yellow-400">★</span>
+          ) : (
+            <span className="text-gray-300">☆</span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── Review Section ───────────────────────────────────────────────────────────
+
+interface ReviewSectionProps {
+  appointmentId: string;
+  isPatient: boolean;
+  status: AppointmentStatus;
+}
+
+function ReviewSection({
+  appointmentId,
+  isPatient,
+  status,
+}: ReviewSectionProps) {
+  const [existingReview, setExistingReview] = useState<Review | null>(null);
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(isPatient && status === "completed");
+
+  useSyncExternalStore(
+    () => () => {},
+    () =>
+      (loading
+        ? "loading"
+        : done || existingReview
+          ? "reviewed"
+          : "form") as string,
+    () => "loading"
+  );
+
+  // Load existing review (only for completed appointments owned by patient)
+  if (isPatient && status === "completed" && loading) {
+    const cancelled = false;
+    reviewsApi
+      .getByAppointment(appointmentId)
+      .then((review) => {
+        if (!cancelled) {
+          setExistingReview(review);
+          setDone(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return <div className="py-4 text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  if (!isPatient || status !== "completed") return null;
+  if (loading) return null;
+
+  if (done || existingReview) {
+    return (
+      <div
+        className="rounded-lg border border-border bg-card p-6"
+        data-testid="review-submitted"
+      >
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-green-500 text-xl">✓</span>
+          <h2 className="text-base font-semibold text-foreground">
+            Review Submitted
+          </h2>
+        </div>
+        {existingReview && (
+          <div className="mt-3">
+            <div className="flex items-center gap-1 mb-1">
+              <span className="text-yellow-400">
+                {"★".repeat(existingReview.rating)}
+              </span>
+              <span className="text-gray-300">
+                {"☆".repeat(5 - existingReview.rating)}
+              </span>
+            </div>
+            {existingReview.comment && (
+              <p className="text-sm text-muted-foreground">
+                {existingReview.comment}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (rating === 0) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await reviewsApi.create({
+        appointmentId,
+        rating,
+        comment: comment || null,
+      });
+      setDone(true);
+    } catch (err: any) {
+      const msg = err?.response?.data?.message ?? "Failed to submit review.";
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="rounded-lg border border-border bg-card p-6"
+      data-testid="review-section"
+    >
+      <h2 className="mb-4 text-base font-semibold text-foreground">
+        How was your visit?
+      </h2>
+
+      {error && (
+        <p
+          data-testid="review-error"
+          className="mb-3 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </p>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="text-sm font-medium mb-2 block">Rating</label>
+          <StarPicker
+            value={rating}
+            onChange={setRating}
+            disabled={submitting}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="review-comment" className="text-sm font-medium">
+            Comment{" "}
+            <span className="text-muted-foreground font-normal">
+              (optional)
+            </span>
+          </label>
+          <textarea
+            id="review-comment"
+            data-testid="review-comment-input"
+            rows={3}
+            maxLength={500}
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            disabled={submitting}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+            placeholder="Share your experience…"
+          />
+          <p className="text-xs text-muted-foreground text-right">
+            {comment.length}/500
+          </p>
+        </div>
+
+        <button
+          type="submit"
+          data-testid="review-submit"
+          disabled={submitting || rating === 0}
+          className="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {submitting ? "Submitting…" : "Submit Review"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
 // ─── Page ──────────────────────────────────────────────────────────────────────
 
 export function AppointmentDetailPage() {
@@ -446,6 +651,13 @@ export function AppointmentDetailPage() {
           appointmentId={appointment.id}
           initialRecord={initialRecord}
           role={user?.role}
+          status={status}
+        />
+
+        {/* Review section */}
+        <ReviewSection
+          appointmentId={appointment.id}
+          isPatient={user?.role === "patient"}
           status={status}
         />
       </div>

--- a/apps/web/src/pages/doctor-profile.test.tsx
+++ b/apps/web/src/pages/doctor-profile.test.tsx
@@ -68,6 +68,8 @@ const mockDoctor: Doctor = {
     imageUrl: null,
     isActive: true,
   },
+  averageRating: null,
+  reviewCount: 0,
 };
 
 const mockSchedule: DoctorSchedule[] = [

--- a/apps/web/src/pages/doctor-profile.tsx
+++ b/apps/web/src/pages/doctor-profile.tsx
@@ -1,13 +1,13 @@
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import {
   useParams,
   useNavigate,
   useLoaderData,
   useNavigation,
 } from "react-router";
-import { doctorsApi, schedulesApi } from "@/lib/api-client";
+import { doctorsApi, schedulesApi, reviewsApi } from "@/lib/api-client";
 import { useAuthStore } from "@/stores/auth-store";
-import type { Doctor, DoctorSchedule } from "@caresync/shared";
+import type { Doctor, DoctorSchedule, DoctorReview } from "@caresync/shared";
 import { ArrowLeft, Mail, Phone, Award, Building2, Star } from "lucide-react";
 
 // ─── Loader ────────────────────────────────────────────────────────────────────
@@ -319,6 +319,157 @@ function DoctorAvailabilityViewer({ doctorId }: { doctorId: string }) {
   );
 }
 
+// ─── Reviews Section ─────────────────────────────────────────────────────────
+
+interface ReviewsSectionProps {
+  doctorId: string;
+  initialAverageRating: number | null;
+  initialReviewCount: number;
+}
+
+function ReviewsSection({
+  doctorId,
+  initialAverageRating,
+  initialReviewCount,
+}: ReviewsSectionProps) {
+  const [reviews, setReviews] = useState<DoctorReview[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const limit = 5;
+
+  const loadReviews = (pageNum: number) => {
+    setLoading(true);
+    reviewsApi
+      .getByDoctor(doctorId, { page: pageNum, limit })
+      .then((res) => {
+        setReviews(res.data);
+        setTotalPages(res.totalPages);
+        setPage(res.page);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
+  useSyncExternalStore(
+    () => () => {},
+    () => "ready",
+    () => "ready"
+  );
+
+  if (initialReviewCount === 0 && reviews.length === 0) {
+    return (
+      <div
+        className="rounded-lg border border-border bg-card p-6"
+        data-testid="reviews-section"
+      >
+        <h2 className="mb-4 text-base font-semibold text-foreground">
+          Patient Reviews
+        </h2>
+        <p className="text-sm text-muted-foreground py-4">No reviews yet.</p>
+      </div>
+    );
+  }
+
+  const avgRating = initialAverageRating ?? 0;
+
+  return (
+    <div
+      className="rounded-lg border border-border bg-card p-6"
+      data-testid="reviews-section"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-semibold text-foreground">
+          Patient Reviews
+        </h2>
+        {initialReviewCount > 0 && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-yellow-400 text-lg">★</span>
+            <span className="font-medium text-sm">
+              {avgRating > 0 ? avgRating.toFixed(1) : "N/A"}
+            </span>
+            <span className="text-sm text-muted-foreground">
+              ({initialReviewCount})
+            </span>
+          </div>
+        )}
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground py-4">Loading reviews…</p>
+      ) : reviews.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">No reviews yet.</p>
+      ) : (
+        <>
+          <div className="space-y-4">
+            {reviews.map((review) => (
+              <div
+                key={review.id}
+                className="border-b border-border pb-3 last:border-0 last:pb-0"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm font-medium">
+                    {review.patientFirstName}{" "}
+                    {review.patientLastName?.charAt(0)}.
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-yellow-400 text-sm">
+                      {"★".repeat(review.rating)}
+                    </span>
+                    <span className="text-gray-300 text-sm">
+                      {"☆".repeat(5 - review.rating)}
+                    </span>
+                  </div>
+                </div>
+                {review.comment && (
+                  <p className="text-sm text-muted-foreground">
+                    {review.comment}
+                  </p>
+                )}
+                <p className="text-xs text-gray-400 mt-1">
+                  {new Date(review.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-4">
+              <button
+                data-testid="reviews-prev"
+                disabled={page <= 1 || loading}
+                onClick={() => {
+                  const p = page - 1;
+                  setPage(p);
+                  loadReviews(p);
+                }}
+                className="px-3 py-1 text-sm rounded-md border border-border hover:bg-muted disabled:opacity-50"
+              >
+                ← Prev
+              </button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </span>
+              <button
+                data-testid="reviews-next"
+                disabled={page >= totalPages || loading}
+                onClick={() => {
+                  const p = page + 1;
+                  setPage(p);
+                  loadReviews(p);
+                }}
+                className="px-3 py-1 text-sm rounded-md border border-border hover:bg-muted disabled:opacity-50"
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 // ─── Doctor profile page ──────────────────────────────────────────────────────
 
 export function DoctorProfilePage() {
@@ -381,7 +532,11 @@ export function DoctorProfilePage() {
                 <Star className="h-4 w-4 fill-current" />
                 <Star className="h-4 w-4" />
                 <span className="ml-1 text-sm text-muted-foreground">
-                  (4.0)
+                  (
+                  {doctor.averageRating != null
+                    ? doctor.averageRating.toFixed(1)
+                    : "N/A"}
+                  )
                 </span>
               </div>
             </div>
@@ -444,6 +599,13 @@ export function DoctorProfilePage() {
             </h2>
             <DoctorAvailabilityViewer doctorId={doctor.id} />
           </div>
+
+          {/* Patient Reviews */}
+          <ReviewsSection
+            doctorId={doctor.id}
+            initialAverageRating={doctor.averageRating}
+            initialReviewCount={doctor.reviewCount}
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/doctors.test.tsx
+++ b/apps/web/src/pages/doctors.test.tsx
@@ -86,6 +86,8 @@ const mockDoctors: Doctor[] = [
       updatedAt: "2024-01-01",
     },
     department: mockDepts[0],
+    averageRating: null,
+    reviewCount: 0,
   },
 ];
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -37,6 +37,8 @@ export interface Doctor {
   licenseNumber: string;
   user?: User;
   department?: Department;
+  averageRating: number | null;
+  reviewCount: number;
 }
 
 export interface DoctorSchedule {
@@ -154,6 +156,25 @@ export interface Review {
   comment: string | null;
   createdAt: string;
   patient?: Patient;
+}
+
+export interface DoctorReview {
+  id: string;
+  appointmentId: string;
+  doctorId: string;
+  rating: number;
+  comment: string | null;
+  createdAt: string;
+  patientFirstName: string;
+  patientLastName: string;
+}
+
+export interface PaginatedDoctorReviewsResponse {
+  data: DoctorReview[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
 }
 
 export interface Notification {


### PR DESCRIPTION
## Summary

Patient can submit star rating + comment after a completed appointment. Doctor profile shows average rating and paginated reviews.

## Changes

### Backend (API)
- `POST /api/v1/reviews` — create review (patient, appointment, rating 1-5, optional comment)
- `GET /api/v1/reviews/appointment/:id` — check if appointment already reviewed
- `GET /api/v1/doctors/:id/reviews` — paginated reviews (5/page, newest first)
- `Doctor.averageRating` + `reviewCount` fields computed from reviews table

### Frontend (Web)
- **Appointment detail page** — `ReviewSection` with star picker (★ 1-5), optional comment (500 char), shows submitted review after submit
- **Doctor profile page** — `ReviewsSection` showing average rating + paginated reviews (Prev/Next)
- Doctor card now shows real `averageRating` instead of hardcoded 4.0

### Types
- `Doctor` now has `averageRating: number | null` + `reviewCount: number`
- New `DoctorReview` + `PaginatedDoctorReviewsResponse` types
- `reviewsApi` added to api-client

## Test Results
- API: 309/309 tests pass
- Web: 111/111 tests pass

## Checklist
- [ ] Tests pass
- [ ] No ESLint errors