### PR TITLE
feat: add staging deployment to app.testingwithekki.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,41 @@ jobs:
 
       - name: Build all packages
         run: pnpm build
+
+  deploy:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    needs: [build]
+    # Only deploy on pushes to main, not on PRs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: staging
+      url: https://app.testingwithekki.com
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ vars.DEPLOY_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Sync source to VPS
+        run: |
+          rsync -az --delete \
+            --exclude='.git' \
+            --exclude='node_modules' \
+            --exclude='apps/*/node_modules' \
+            --exclude='apps/web/dist' \
+            --exclude='apps/e2e' \
+            --exclude='.env*' \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            ./ \
+            ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }}:${{ vars.DEPLOY_DIR }}/
+
+      - name: Build and restart containers on VPS
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }} \
+            "cd ${{ vars.DEPLOY_DIR }} && \
+             docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build"

--- a/apps/web/src/pages/invoices.test.tsx
+++ b/apps/web/src/pages/invoices.test.tsx
@@ -66,7 +66,7 @@ const baseInvoice = {
   tax: 10.0,
   total: 110.0,
   status: "pending" as InvoiceStatus,
-  dueDate: "2026-04-20",
+  dueDate: "2099-12-31",
   paidAt: null,
 };
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,48 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: caresync-db
+    environment:
+      POSTGRES_DB: caresync
+      POSTGRES_USER: caresync
+      POSTGRES_PASSWORD: caresync123
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U caresync"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    container_name: caresync-api
+    environment:
+      DATABASE_URL: postgresql://caresync:caresync123@postgres:5432/caresync
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
+      PORT: 3001
+    volumes:
+      - uploads:/app/apps/api/uploads
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    container_name: caresync-web
+    ports:
+      - "8181:80"
+    depends_on:
+      - api
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  uploads:

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_HOST="deploy@103.235.75.99"
+REMOTE_DIR="/home/deploy/caresync"
+COMPOSE_FILE="docker-compose.staging.yml"
+
+# Generate secrets if not provided via env
+JWT_SECRET="${JWT_SECRET:-$(openssl rand -hex 32)}"
+JWT_REFRESH_SECRET="${JWT_REFRESH_SECRET:-$(openssl rand -hex 32)}"
+
+echo "==> Syncing source to VPS..."
+rsync -az --delete \
+  --exclude='.git' \
+  --exclude='node_modules' \
+  --exclude='apps/*/node_modules' \
+  --exclude='apps/web/dist' \
+  --exclude='apps/e2e' \
+  --exclude='.env*' \
+  /Users/ekkisyam/Learn/caresync/ \
+  "${DEPLOY_HOST}:${REMOTE_DIR}/"
+
+echo "==> Writing .env.staging on VPS..."
+ssh "${DEPLOY_HOST}" "cat > ${REMOTE_DIR}/.env.staging <<EOF
+JWT_SECRET=${JWT_SECRET}
+JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET}
+EOF"
+
+echo "==> Building and starting containers..."
+ssh "${DEPLOY_HOST}" "cd ${REMOTE_DIR} && docker compose -f ${COMPOSE_FILE} --env-file .env.staging up -d --build"
+
+echo "==> Waiting for services to be healthy..."
+ssh "${DEPLOY_HOST}" "cd ${REMOTE_DIR} && docker compose -f ${COMPOSE_FILE} ps"
+
+echo "==> Done. caresync is running on port 8181"

--- a/scripts/nginx-caresync.conf
+++ b/scripts/nginx-caresync.conf
@@ -1,0 +1,30 @@
+server {
+    listen 80;
+    server_name app.testingwithekki.com;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name app.testingwithekki.com;
+
+    ssl_certificate /etc/letsencrypt/live/app.testingwithekki.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/app.testingwithekki.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Increase upload limit for medical record attachments
+    client_max_body_size 20M;
+
+    location / {
+        proxy_pass http://localhost:8181;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
- docker-compose.staging.yml: web on port 8181, JWT secrets from env file
- scripts/nginx-caresync.conf: nginx reverse proxy with SSL
- scripts/deploy-staging.sh: manual deploy helper
- ci.yml: deploy job that rsyncs to VPS and runs docker compose build on the server (no Docker build on CI runner); gates on build passing, main-only