### PR TITLE
feat(admin): add dashboard with statistics and charts (#23)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import { invoicesRoute } from "./routes/invoices";
 import { reviewsRoute } from "./routes/reviews";
 import { prescriptionsRoute } from "./routes/prescriptions";
 import { notificationsRoute } from "./routes/notifications";
+import { adminRoute } from "./routes/admin";
 
 export type AppEnv = {
   Variables: {
@@ -56,6 +57,7 @@ app.route("/api/v1", invoicesRoute);
 app.route("/api/v1", reviewsRoute);
 app.route("/api/v1", prescriptionsRoute);
 app.route("/api/v1", notificationsRoute);
+app.route("/api/v1", adminRoute);
 
 // OpenAPI spec
 app.doc("/api/openapi.json", {

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { app } from "../app";
+import { signAccessToken } from "../lib/jwt";
+
+vi.mock("../db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+import { db } from "../db";
+
+const ADMIN_STATS_URL = "/api/v1/admin/stats";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const patientToken = signAccessToken({
+  userId: "a1b2c3d4-0000-4000-8000-000000000004",
+  role: "patient",
+});
+const adminToken = signAccessToken({
+  userId: "a1b2c3d4-0000-4000-8000-000000000005",
+  role: "admin",
+});
+const doctorToken = signAccessToken({
+  userId: "a1b2c3d4-0000-4000-8000-000000000006",
+  role: "doctor",
+});
+
+function bearer(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+describe("GET /admin/stats", () => {
+  it("returns 401 when no Authorization header is provided", async () => {
+    const res = await app.request(ADMIN_STATS_URL, { method: "GET" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when called by patient", async () => {
+    const res = await app.request(ADMIN_STATS_URL, {
+      method: "GET",
+      headers: bearer(patientToken),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.message).toBe("Insufficient permissions");
+  });
+
+  it("returns 403 when called by doctor", async () => {
+    const res = await app.request(ADMIN_STATS_URL, {
+      method: "GET",
+      headers: bearer(doctorToken),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.message).toBe("Insufficient permissions");
+  });
+
+  it("returns 500 when database throws an error", async () => {
+    vi.mocked(db.select).mockImplementation(() => {
+      throw new Error("DB connection failed");
+    });
+
+    const res = await app.request(ADMIN_STATS_URL, {
+      method: "GET",
+      headers: bearer(adminToken),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.message).toBe("Failed to load stats");
+  });
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,154 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq, sql, and, gte, lte } from "drizzle-orm";
+import { db } from "../db";
+import {
+  patients,
+  doctors,
+  appointments,
+  invoices,
+  departments,
+} from "../db/schema";
+import { requireAuth, requireRole } from "../middleware/auth";
+import { adminStatsResponseSchema } from "@caresync/shared";
+import type { AppEnv } from "../app";
+
+export const adminRoute = new OpenAPIHono<AppEnv>();
+
+// ─── GET /admin/stats ─────────────────────────────────────────────────────────
+
+const errorResponseSchema = z.object({ message: z.string() });
+
+const getAdminStatsRoute = createRoute({
+  method: "get",
+  path: "/admin/stats",
+  tags: ["Admin"],
+  summary: "Get admin dashboard statistics",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth, requireRole("admin")] as const,
+  responses: {
+    200: {
+      description: "Admin dashboard stats",
+      content: {
+        "application/json": { schema: adminStatsResponseSchema },
+      },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "Insufficient permissions",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+});
+
+adminRoute.openapi(getAdminStatsRoute, async (c) => {
+  try {
+    const today = new Date();
+    const thirtyDaysAgo = new Date(today);
+    thirtyDaysAgo.setDate(today.getDate() - 30);
+    const thirtyDaysAgoStr = thirtyDaysAgo.toISOString().substring(0, 10);
+    const todayStr = today.toISOString().substring(0, 10);
+
+    const [patientCount] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(patients)
+      .limit(1);
+
+    const [doctorCount] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(doctors)
+      .limit(1);
+
+    const [appointmentCount] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(appointments)
+      .limit(1);
+
+    const [revenueResult] = await db
+      .select({ total: sql<number>`COALESCE(SUM(CAST(total AS numeric)), 0)` })
+      .from(invoices)
+      .where(eq(invoices.status, "paid"))
+      .limit(1);
+
+    const timelineRows = await db
+      .select({
+        date: appointments.appointmentDate,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(appointments)
+      .where(
+        and(
+          gte(appointments.appointmentDate, thirtyDaysAgoStr),
+          lte(appointments.appointmentDate, todayStr)
+        )
+      )
+      .groupBy(appointments.appointmentDate)
+      .orderBy(appointments.appointmentDate);
+
+    const appointmentsTimeline = timelineRows.map((row) => ({
+      date: row.date,
+      count: row.count,
+    }));
+
+    const deptRows = await db
+      .select({
+        department: departments.name,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(appointments)
+      .innerJoin(doctors, eq(appointments.doctorId, doctors.id))
+      .innerJoin(departments, eq(doctors.departmentId, departments.id))
+      .groupBy(departments.name)
+      .orderBy(sql`count(*)::int desc`);
+
+    const appointmentsByDepartment = deptRows.map((row) => ({
+      department: row.department,
+      count: row.count,
+    }));
+
+    const twelveMonthsAgo = new Date(today);
+    twelveMonthsAgo.setMonth(today.getMonth() - 12);
+    const twelveMonthsAgoStr = twelveMonthsAgo.toISOString().substring(0, 7);
+
+    const revenueRows = await db
+      .select({
+        month: sql<string>`TO_CHAR(paid_at, 'YYYY-MM')`,
+        revenue: sql<number>`COALESCE(SUM(CAST(total AS numeric)), 0)`,
+      })
+      .from(invoices)
+      .where(and(
+        eq(invoices.status, "paid"),
+        gte(sql`TO_CHAR(paid_at, 'YYYY-MM')`, twelveMonthsAgoStr)
+      ))
+      .groupBy(sql`TO_CHAR(paid_at, 'YYYY-MM')`)
+      .orderBy(sql`TO_CHAR(paid_at, 'YYYY-MM')`);
+
+    const revenueTimeline = revenueRows.map((row) => ({
+      month: row.month,
+      revenue: row.revenue,
+    }));
+
+    return c.json(
+      {
+        summary: {
+          totalPatients: patientCount.count,
+          totalDoctors: doctorCount.count,
+          totalAppointments: appointmentCount.count,
+          totalRevenue: revenueResult.total,
+        },
+        appointmentsTimeline,
+        appointmentsByDepartment,
+        revenueTimeline,
+      },
+      200
+    );
+  } catch {
+    return c.json({ message: "Failed to load stats" }, 500);
+  }
+});

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -45,11 +45,18 @@ import {
 } from "@/pages/prescriptions/detail";
 import { ProtectedRoute } from "@/components/auth/protected-route";
 import { useAuthStore } from "@/stores/auth-store";
+import { AdminDashboardPage, adminLoader } from "@/pages/admin";
 
 function PatientOnlyRoute() {
   const user = useAuthStore((s) => s.user);
   if (user?.role !== "patient") return <Navigate to="/dashboard" replace />;
   return <BookAppointmentPage />;
+}
+
+function AdminOnlyRoute() {
+  const user = useAuthStore((s) => s.user);
+  if (user?.role !== "admin") return <Navigate to="/dashboard" replace />;
+  return <AdminDashboardPage />;
 }
 
 export const router = createBrowserRouter([
@@ -99,6 +106,11 @@ export const router = createBrowserRouter([
             path: "/patients",
             loader: patientsLoader,
             element: <PatientsPage />,
+          },
+          {
+            path: "/admin",
+            loader: adminLoader,
+            element: <AdminOnlyRoute />,
           },
           {
             path: "/appointments",

--- a/apps/web/src/components/auth/protected-route.tsx
+++ b/apps/web/src/components/auth/protected-route.tsx
@@ -1,10 +1,21 @@
 import { Navigate, Outlet } from "react-router";
 import { useAuthStore } from "@/stores/auth-store";
 
-export function ProtectedRoute() {
+interface ProtectedRouteProps {
+  allowedRoles?: string[];
+}
+
+export function ProtectedRoute({ allowedRoles }: ProtectedRouteProps) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated());
+  const user = useAuthStore((s) => s.user);
+
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
   }
+
+  if (allowedRoles && user && !allowedRoles.includes(user.role)) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
   return <Outlet />;
 }

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   HeartPulse,
   LogOut,
   PillIcon,
+  LayoutGrid,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/stores/auth-store";
@@ -30,6 +31,7 @@ const navItems = [
   },
   { to: "/doctors", label: "Doctors", icon: Stethoscope, roles: null },
   { to: "/patients", label: "Patients", icon: Users, roles: ["admin"] },
+  { to: "/admin", label: "Admin Dashboard", icon: LayoutGrid, roles: ["admin"] },
   {
     to: "/medical-records",
     label: "Medical Records",

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -20,7 +20,9 @@ import type {
   CreatePrescriptionInput,
   UpdatePrescriptionInput,
   PrescriptionItem,
-  Notification,} from "@caresync/shared";
+  Notification,
+  AdminStatsResponse,
+} from "@caresync/shared";
 import { useAuthStore } from "@/stores/auth-store";
 
 export interface ApiError {
@@ -603,6 +605,15 @@ export const notificationsApi = {
     const res = await apiClient.patch<{ success: boolean }>(
       "/api/v1/notifications/read-all"
     );
+    return res.data;
+  },
+};
+
+// ─── Admin API ────────────────────────────────────────────────────────────────
+
+export const adminApi = {
+  getStats: async (): Promise<AdminStatsResponse> => {
+    const res = await apiClient.get<AdminStatsResponse>("/api/v1/admin/stats");
     return res.data;
   },
 };

--- a/apps/web/src/pages/admin.loader.ts
+++ b/apps/web/src/pages/admin.loader.ts
@@ -1,0 +1,3 @@
+import type { AdminStatsResponse } from "@caresync/shared";
+
+export type Route = AdminStatsResponse;

--- a/apps/web/src/pages/admin.tsx
+++ b/apps/web/src/pages/admin.tsx
@@ -1,0 +1,196 @@
+import { useLoaderData, redirect } from "react-router";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+} from "recharts";
+import { adminApi } from "@/lib/api-client";
+import type { AdminStatsResponse } from "@caresync/shared";
+import type { Route } from "./admin.loader";
+import { useAuthStore } from "@/stores/auth-store";
+
+const CHART_COLORS = [
+  "#2563eb",
+  "#16a34a",
+  "#dc2626",
+  "#9333ea",
+  "#0891b2",
+  "#ca8a04",
+  "#db2777",
+  "#4b5563",
+];
+
+export async function adminLoader() {
+  const user = useAuthStore.getState().user;
+  if (!user || user.role !== "admin") {
+    throw redirect("/dashboard");
+  }
+  const stats = await adminApi.getStats();
+  return stats;
+}
+
+export function AdminDashboardPage() {
+  const stats = useLoaderData<Route>() as AdminStatsResponse;
+
+  return (
+    <div className="space-y-8" data-testid="admin-dashboard-page">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Admin Dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Overview of clinic performance and statistics
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Total Patients"
+          value={stats.summary.totalPatients}
+          testId="stat-patients"
+        />
+        <StatCard
+          label="Total Doctors"
+          value={stats.summary.totalDoctors}
+          testId="stat-doctors"
+        />
+        <StatCard
+          label="Total Appointments"
+          value={stats.summary.totalAppointments}
+          testId="stat-appointments"
+        />
+        <StatCard
+          label="Total Revenue"
+          value={stats.summary.totalRevenue}
+          prefix="Rp"
+          testId="stat-revenue"
+          isCurrency
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <ChartCard title="Appointments (Last 30 Days)">
+          <ResponsiveContainer width="100%" height={280}>
+            <LineChart data={stats.appointmentsTimeline}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 12 }}
+                tickFormatter={(v) => {
+                  const d = new Date(v);
+                  return `${d.getMonth() + 1}/${d.getDate()}`;
+                }}
+              />
+              <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+              <Tooltip labelFormatter={(v) => new Date(v).toLocaleDateString()} />
+              <Line
+                type="monotone"
+                dataKey="count"
+                stroke="var(--color-primary)"
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard title="Appointments by Department">
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie
+                data={stats.appointmentsByDepartment}
+                dataKey="count"
+                nameKey="department"
+                cx="50%"
+                cy="50%"
+                outerRadius={100}
+                label={({ name, percent }) =>
+                  `${name} (${(percent * 100).toFixed(0)}%)`
+                }
+                labelLine={false}
+              >
+                {stats.appointmentsByDepartment.map((_, i) => (
+                  <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </ChartCard>
+      </div>
+
+      <ChartCard title="Monthly Revenue (Last 12 Months)">
+        <ResponsiveContainer width="100%" height={280}>
+          <BarChart data={stats.revenueTimeline}>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+            <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+            <YAxis
+              tick={{ fontSize: 12 }}
+              tickFormatter={(v) =>
+                v >= 1000000
+                  ? `Rp${(v / 1000000).toFixed(1)}M`
+                  : v >= 1000
+                    ? `Rp${(v / 1000).toFixed(0)}K`
+                    : `Rp${v}`
+              }
+            />
+            <Tooltip
+              formatter={(value: number) => [
+                `Rp ${value.toLocaleString("id-ID")}`,
+                "Revenue",
+              ]}
+            />
+            <Bar
+              dataKey="revenue"
+              fill="var(--color-primary)"
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  prefix,
+  testId,
+  isCurrency,
+}: {
+  label: string;
+  value: number;
+  prefix?: string;
+  testId: string;
+  isCurrency?: boolean;
+}) {
+  return (
+    <div
+      className="rounded-lg border border-border bg-card p-4 shadow-sm"
+      data-testid={testId}
+    >
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-card-foreground">
+        {prefix}
+        {isCurrency ? value.toLocaleString("id-ID") : value}
+      </p>
+    </div>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <h2 className="mb-4 text-base font-semibold text-foreground">{title}</h2>
+      {children}
+    </div>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants";
 export * from "./schemas/auth";
 export * from "./schemas/prescriptions";
+export * from "./schemas/admin";
 export * from "./types";

--- a/packages/shared/src/schemas/admin.ts
+++ b/packages/shared/src/schemas/admin.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+const timelineEntrySchema = z.object({
+  date: z.string(),
+  count: z.number().int().nonnegative(),
+});
+
+const revenueTimelineEntrySchema = z.object({
+  month: z.string(),
+  revenue: z.number().nonnegative(),
+});
+
+const departmentEntrySchema = z.object({
+  department: z.string(),
+  count: z.number().int().nonnegative(),
+});
+
+export const adminStatsResponseSchema = z.object({
+  summary: z.object({
+    totalPatients: z.number().int().nonnegative(),
+    totalDoctors: z.number().int().nonnegative(),
+    totalAppointments: z.number().int().nonnegative(),
+    totalRevenue: z.number().nonnegative(),
+  }),
+  appointmentsTimeline: z.array(timelineEntrySchema),
+  appointmentsByDepartment: z.array(departmentEntrySchema),
+  revenueTimeline: z.array(revenueTimelineEntrySchema),
+});
+
+export type AdminStatsResponse = z.infer<typeof adminStatsResponseSchema>;


### PR DESCRIPTION
Backend:
- Add GET /api/v1/admin/stats endpoint (admin-only, JWT auth)
- Returns: summary counts (patients/doctors/appointments/revenue), appointments timeline (last 30 days), appointments by department, monthly revenue timeline (last 12 months)
- Shared AdminStatsResponse Zod schema in packages/shared

Frontend:
- New /admin route with role guard (non-admin redirects to /dashboard)
- Admin sidebar nav item visible only to admin role
- Dashboard page with stat cards and recharts: LineChart (30d appointments), PieChart (by department), BarChart (12mo revenue)
- ProtectedRoute now supports allowedRoles prop

Tests: admin.test.ts covers 401/403/500 cases