### PR TITLE
feat: role-based navigation and dashboards

### DIFF
--- a/apps/api/src/routes/doctors.ts
+++ b/apps/api/src/routes/doctors.ts
@@ -165,6 +165,138 @@ doctorsRoute.openapi(listDoctorsRoute, async (c) => {
   );
 });
 
+// ─── GET /doctors/me ──────────────────────────────────────────────────────────
+
+const doctorMeStatsResponse = z.object({
+  id: z.string(),
+  userId: z.string(),
+  departmentId: z.string(),
+  specialization: z.string(),
+  bio: z.string().nullable(),
+  licenseNumber: z.string(),
+  averageRating: z.number().nullable(),
+  reviewCount: z.number(),
+  user: userResponse,
+  department: departmentResponse,
+  stats: z.object({
+    totalAppointments: z.number(),
+    uniquePatients: z.number(),
+    todayAppointments: z.number(),
+  }),
+});
+
+const getDoctorMeRoute = createRoute({
+  method: "get",
+  path: "/doctors/me",
+  tags: ["Doctors"],
+  summary: "Get authenticated doctor's own profile and stats",
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAuth] as const,
+  responses: {
+    200: {
+      description: "Doctor profile and stats",
+      content: {
+        "application/json": { schema: doctorMeStatsResponse },
+      },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    403: {
+      description: "Not a doctor",
+      content: { "application/json": { schema: errorResponse } },
+    },
+    404: {
+      description: "Doctor profile not found",
+      content: { "application/json": { schema: errorResponse } },
+    },
+  },
+});
+
+doctorsRoute.openapi(getDoctorMeRoute, async (c) => {
+  const userId = c.get("userId");
+  const userRole = c.get("userRole");
+
+  if (userRole !== "doctor") {
+    return c.json({ message: "Forbidden: not a doctor" }, 403);
+  }
+
+  const [doctor] = await db
+    .select({
+      id: doctors.id,
+      userId: doctors.userId,
+      departmentId: doctors.departmentId,
+      specialization: doctors.specialization,
+      bio: doctors.bio,
+      licenseNumber: doctors.licenseNumber,
+      user: {
+        id: users.id,
+        email: users.email,
+        role: users.role,
+        firstName: users.firstName,
+        lastName: users.lastName,
+        phone: users.phone,
+        avatarUrl: users.avatarUrl,
+      },
+      department: {
+        id: departments.id,
+        name: departments.name,
+      },
+    })
+    .from(doctors)
+    .innerJoin(users, eq(doctors.userId, users.id))
+    .innerJoin(departments, eq(doctors.departmentId, departments.id))
+    .where(eq(doctors.userId, userId))
+    .limit(1);
+
+  if (!doctor) {
+    return c.json({ message: "Doctor profile not found" }, 404);
+  }
+
+  const today = new Date().toISOString().substring(0, 10);
+
+  const [reviewStats] = await db
+    .select({
+      averageRating: sql<number | null>`avg(rating)::float`,
+      reviewCount: count(reviews.id),
+    })
+    .from(reviews)
+    .where(eq(reviews.doctorId, doctor.id));
+
+  const [appointmentStats] = await db
+    .select({
+      totalAppointments: count(appointments.id),
+      uniquePatients: sql<number>`count(DISTINCT ${appointments.patientId})`,
+    })
+    .from(appointments)
+    .where(eq(appointments.doctorId, doctor.id));
+
+  const [todayAppointments] = await db
+    .select({ count: count(appointments.id) })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.doctorId, doctor.id),
+        eq(appointments.appointmentDate, today)
+      )
+    );
+
+  return c.json(
+    {
+      ...doctor,
+      averageRating: reviewStats?.averageRating ?? null,
+      reviewCount: Number(reviewStats?.reviewCount ?? 0),
+      stats: {
+        totalAppointments: Number(appointmentStats?.totalAppointments ?? 0),
+        uniquePatients: Number(appointmentStats?.uniquePatients ?? 0),
+        todayAppointments: Number(todayAppointments?.count ?? 0),
+      },
+    },
+    200
+  );
+});
+
 // ─── GET /doctors/:id ──────────────────────────────────────────────────────────
 
 const getDoctorRoute = createRoute({

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -4,7 +4,7 @@ import {
   LoaderFunctionArgs,
 } from "react-router";
 import { AppLayout } from "@/layouts/app-layout";
-import { DashboardPage } from "@/pages/dashboard";
+import { DashboardPage, dashboardLoader } from "@/pages/dashboard";
 import { LoginPage } from "@/pages/login";
 import { RegisterPage } from "@/pages/register";
 import { ProfilePage, profileLoader } from "@/pages/profile";
@@ -47,17 +47,42 @@ import { ProtectedRoute } from "@/components/auth/protected-route";
 import { RouteErrorPage } from "@/components/route-error-page";
 import { useAuthStore } from "@/stores/auth-store";
 import { AdminDashboardPage, adminLoader } from "@/pages/admin";
+import {
+  DoctorDashboardPage,
+  doctorDashboardLoader,
+} from "@/pages/doctor-dashboard";
 
-function PatientOnlyRoute() {
-  const user = useAuthStore((s) => s.user);
-  if (user?.role !== "patient") return <Navigate to="/dashboard" replace />;
-  return <BookAppointmentPage />;
+function getRoleDashboard(role: string): string {
+  switch (role) {
+    case "admin":
+      return "/admin";
+    case "doctor":
+      return "/doctor";
+    case "patient":
+      return "/dashboard";
+    default:
+      return "/dashboard";
+  }
 }
 
-function AdminOnlyRoute() {
+function RoleOnlyRoute({
+  allowedRole,
+  children,
+}: {
+  allowedRole: string;
+  children: React.ReactNode;
+}) {
   const user = useAuthStore((s) => s.user);
-  if (user?.role !== "admin") return <Navigate to="/dashboard" replace />;
-  return <AdminDashboardPage />;
+  if (user?.role !== allowedRole) {
+    return <Navigate to={user ? getRoleDashboard(user.role) : "/login"} replace />;
+  }
+  return <>{children}</>;
+}
+
+function RootRedirect() {
+  const user = useAuthStore((s) => s.user);
+  if (!user) return <Navigate to="/login" replace />;
+  return <Navigate to={getRoleDashboard(user.role)} replace />;
 }
 
 export const router = createBrowserRouter([
@@ -69,20 +94,30 @@ export const router = createBrowserRouter([
     path: "/register",
     element: <RegisterPage />,
   },
-{
-        element: <ProtectedRoute />,
+  {
+    element: <ProtectedRoute />,
         errorElement: <RouteErrorPage />,
         children: [
       {
         path: "/",
-        element: <Navigate to="/dashboard" replace />,
+        element: <RootRedirect />,
       },
       {
         element: <AppLayout />,
         children: [
           {
             path: "/dashboard",
+            loader: dashboardLoader,
             element: <DashboardPage />,
+          },
+          {
+            path: "/doctor",
+            loader: doctorDashboardLoader,
+            element: (
+              <RoleOnlyRoute allowedRole="doctor">
+                <DoctorDashboardPage />
+              </RoleOnlyRoute>
+            ),
           },
           {
             path: "/profile",
@@ -112,7 +147,11 @@ export const router = createBrowserRouter([
           {
             path: "/admin",
             loader: adminLoader,
-            element: <AdminOnlyRoute />,
+            element: (
+              <RoleOnlyRoute allowedRole="admin">
+                <AdminDashboardPage />
+              </RoleOnlyRoute>
+            ),
           },
           {
             path: "/appointments",
@@ -127,7 +166,11 @@ export const router = createBrowserRouter([
           {
             path: "/appointments/book",
             loader: bookAppointmentLoader,
-            element: <PatientOnlyRoute />,
+            element: (
+              <RoleOnlyRoute allowedRole="patient">
+                <BookAppointmentPage />
+              </RoleOnlyRoute>
+            ),
           },
           {
             path: "/medical-records",

--- a/apps/web/src/components/auth/protected-route.tsx
+++ b/apps/web/src/components/auth/protected-route.tsx
@@ -5,6 +5,19 @@ interface ProtectedRouteProps {
   allowedRoles?: string[];
 }
 
+function getRoleDashboard(role: string): string {
+  switch (role) {
+    case "admin":
+      return "/admin";
+    case "doctor":
+      return "/doctor";
+    case "patient":
+      return "/dashboard";
+    default:
+      return "/dashboard";
+  }
+}
+
 export function ProtectedRoute({ allowedRoles }: ProtectedRouteProps) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated());
   const user = useAuthStore((s) => s.user);
@@ -14,7 +27,7 @@ export function ProtectedRoute({ allowedRoles }: ProtectedRouteProps) {
   }
 
   if (allowedRoles && user && !allowedRoles.includes(user.role)) {
-    return <Navigate to="/dashboard" replace />;
+    return <Navigate to={getRoleDashboard(user.role)} replace />;
   }
 
   return <Outlet />;

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -13,7 +13,8 @@ import type {
   MedicalRecord,
   MedicalRecordAttachment,
   Invoice,
-  Prescription,  Review,
+  Prescription,
+  Review,
   DoctorReview,
   PaginatedDoctorReviewsResponse,
   PrescriptionResponse,
@@ -22,6 +23,7 @@ import type {
   PrescriptionItem,
   Notification,
   AdminStatsResponse,
+  DoctorMeStatsResponse,
 } from "@caresync/shared";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -244,6 +246,11 @@ export const doctorsApi = {
 
   getDoctor: async (id: string): Promise<Doctor> => {
     const res = await apiClient.get<Doctor>(`/api/v1/doctors/${id}`);
+    return res.data;
+  },
+
+  getDoctorMe: async (): Promise<DoctorMeStatsResponse> => {
+    const res = await apiClient.get<DoctorMeStatsResponse>("/api/v1/doctors/me");
     return res.data;
   },
 

--- a/apps/web/src/pages/dashboard.loader.ts
+++ b/apps/web/src/pages/dashboard.loader.ts
@@ -1,0 +1,11 @@
+import type { AppointmentListItem } from "@/lib/api-client";
+import type { MedicalRecord } from "@caresync/shared";
+import type { Invoice } from "@caresync/shared";
+
+export interface DashboardData {
+  appointments: AppointmentListItem[];
+  medicalRecords: MedicalRecord[];
+  invoices: Invoice[];
+}
+
+export type Route = DashboardData;

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,11 +1,52 @@
-import { Link } from "react-router";
-import { CalendarPlus } from "lucide-react";
+import { Link, redirect } from "react-router";
+import { CalendarPlus, FileText, Receipt, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuthStore } from "@/stores/auth-store";
+import { appointmentsApi, medicalRecordsApi, invoicesApi } from "@/lib/api-client";
+import type { Route } from "./dashboard.loader";
+import type { AppointmentListItem } from "@/lib/api-client";
+import { useLoaderData } from "react-router";
+
+export async function dashboardLoader() {
+  const user = useAuthStore.getState().user;
+  if (!user) {
+    throw redirect("/login");
+  }
+
+  const [appointmentsData, medicalRecordsData, invoicesData] = await Promise.all(
+    [
+      appointmentsApi.list({ limit: 5 }),
+      medicalRecordsApi.list(),
+      invoicesApi.listInvoices({ limit: 5 }),
+    ]
+  );
+
+  return {
+    appointments: appointmentsData.data,
+    medicalRecords: medicalRecordsData.slice(0, 5),
+    invoices: invoicesData.data.slice(0, 5),
+  };
+}
 
 export function DashboardPage() {
-  const user = useAuthStore((s) => s.user);
-  const isPatient = user?.role === "patient";
+  const { appointments, medicalRecords, invoices } = useLoaderData<Route>() as {
+    appointments: AppointmentListItem[];
+    medicalRecords: Array<{
+      id: string;
+      diagnosis: string;
+      createdAt: string;
+    }>;
+    invoices: Array<{
+      id: string;
+      amount: number;
+      status: string;
+      dueDate: string;
+    }>;
+  };
+
+  const upcomingAppointments = appointments.filter(
+    (a) => a.status === "pending" || a.status === "confirmed"
+  );
 
   return (
     <div data-testid="dashboard-page">
@@ -16,66 +57,165 @@ export function DashboardPage() {
         </p>
       </div>
 
-      {/* Stat cards */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {[
-          { label: "Total Patients", value: "—", testId: "stat-patients" },
-          { label: "Total Doctors", value: "—", testId: "stat-doctors" },
-          {
-            label: "Appointments Today",
-            value: "—",
-            testId: "stat-appointments",
-          },
-          { label: "Revenue (Month)", value: "—", testId: "stat-revenue" },
-        ].map(({ label, value, testId }) => (
-          <div
-            key={testId}
-            className="rounded-lg border border-border bg-card p-4 shadow-sm"
-            data-testid={testId}
-          >
-            <p className="text-sm font-medium text-muted-foreground">{label}</p>
-            <p className="mt-1 text-2xl font-bold text-card-foreground">
-              {value}
+      <div
+        className="mt-8 rounded-lg border border-primary/20 bg-primary/5 p-6"
+        data-testid="book-appointment-cta"
+      >
+        <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-semibold text-foreground">
+              Ready for your next visit?
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Book an appointment with one of our doctors in just a few steps.
             </p>
           </div>
-        ))}
+          <Link
+            to="/appointments/book"
+            data-testid="dashboard-book-appointment-link"
+            className="flex shrink-0 items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <CalendarPlus className="h-4 w-4" />
+            Book Appointment
+          </Link>
+        </div>
       </div>
 
-      {/* Patient booking CTA */}
-      {isPatient && (
-        <div
-          className="mt-8 rounded-lg border border-primary/20 bg-primary/5 p-6"
-          data-testid="book-appointment-cta"
-        >
-          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="font-semibold text-foreground">
-                Ready for your next visit?
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Book an appointment with one of our doctors in just a few steps.
-              </p>
-            </div>
+      <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-foreground">
+              Upcoming Appointments
+            </h2>
             <Link
-              to="/appointments/book"
-              data-testid="dashboard-book-appointment-link"
-              className="flex shrink-0 items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              to="/appointments"
+              className="text-sm font-medium text-primary hover:underline"
             >
-              <CalendarPlus className="h-4 w-4" />
-              Book Appointment
+              View all
             </Link>
           </div>
+          {upcomingAppointments.length === 0 ? (
+            <div className="rounded-lg border border-border bg-card p-6 text-center">
+              <Calendar className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                No upcoming appointments
+              </p>
+              <Link
+                to="/appointments/book"
+                className="mt-2 inline-block text-sm font-medium text-primary hover:underline"
+              >
+                Book now
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {upcomingAppointments.map((appointment) => (
+                <Link
+                  key={appointment.id}
+                  to={`/appointments/${appointment.id}`}
+                  className="block rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent"
+                >
+                  <p className="font-medium text-card-foreground">
+                    {appointment.doctorName}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {appointment.appointmentDate} at {appointment.startTime}
+                  </p>
+                  <span className="mt-1 inline-block rounded-full bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800">
+                    {appointment.status}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
-      )}
 
-      {/* Placeholder CTA */}
-      <div className="mt-8 rounded-lg border border-border bg-card p-6 text-center">
-        <p className="text-muted-foreground">
-          Full dashboard charts and stats will be available in Task 22.
-        </p>
-        <Button className="mt-4" data-testid="dashboard-cta">
-          Get Started
-        </Button>
+        <div>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-foreground">
+              Recent Medical Records
+            </h2>
+            <Link
+              to="/medical-records"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              View all
+            </Link>
+          </div>
+          {medicalRecords.length === 0 ? (
+            <div className="rounded-lg border border-border bg-card p-6 text-center">
+              <FileText className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">No medical records</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {medicalRecords.map((record) => (
+                <Link
+                  key={record.id}
+                  to={`/medical-records/${record.id}`}
+                  className="block rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent"
+                >
+                  <p className="font-medium text-card-foreground">
+                    {record.diagnosis}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(record.createdAt).toLocaleDateString()}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-foreground">
+              Recent Invoices
+            </h2>
+            <Link
+              to="/invoices"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              View all
+            </Link>
+          </div>
+          {invoices.length === 0 ? (
+            <div className="rounded-lg border border-border bg-card p-6 text-center">
+              <Receipt className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">No invoices</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {invoices.map((invoice) => (
+                <Link
+                  key={invoice.id}
+                  to={`/invoices/${invoice.id}`}
+                  className="block rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent"
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="font-medium text-card-foreground">
+                      Rp {invoice.amount.toLocaleString("id-ID")}
+                    </p>
+                    <span
+                      className={`rounded-full px-2 py-1 text-xs font-medium ${
+                        invoice.status === "paid"
+                          ? "bg-green-100 text-green-800"
+                          : invoice.status === "cancelled"
+                            ? "bg-red-100 text-red-800"
+                            : "bg-yellow-100 text-yellow-800"
+                      }`}
+                    >
+                      {invoice.status}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Due: {new Date(invoice.dueDate).toLocaleDateString()}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/pages/doctor-dashboard.loader.ts
+++ b/apps/web/src/pages/doctor-dashboard.loader.ts
@@ -1,0 +1,9 @@
+import type { DoctorMeStatsResponse } from "@caresync/shared";
+import type { AppointmentListItem } from "@/lib/api-client";
+
+export interface DoctorDashboardData {
+  doctorData: DoctorMeStatsResponse;
+  appointments: AppointmentListItem[];
+}
+
+export type Route = DoctorDashboardData;

--- a/apps/web/src/pages/doctor-dashboard.tsx
+++ b/apps/web/src/pages/doctor-dashboard.tsx
@@ -1,0 +1,187 @@
+import { Link, redirect } from "react-router";
+import { Calendar, Users, Clock, Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuthStore } from "@/stores/auth-store";
+import { doctorsApi, appointmentsApi } from "@/lib/api-client";
+import type { Route } from "./doctor-dashboard.loader";
+import type { DoctorMeStatsResponse } from "@caresync/shared";
+import type { AppointmentListItem } from "@/lib/api-client";
+import { useLoaderData } from "react-router";
+
+export async function doctorDashboardLoader() {
+  const user = useAuthStore.getState().user;
+  if (!user || user.role !== "doctor") {
+    throw redirect("/doctor");
+  }
+
+  const [doctorData, appointmentsData] = await Promise.all([
+    doctorsApi.getDoctorMe(),
+    appointmentsApi.list({ limit: 5 }),
+  ]);
+
+  return { doctorData, appointments: appointmentsData.data };
+}
+
+export function DoctorDashboardPage() {
+  const { doctorData, appointments } = useLoaderData<Route>() as {
+    doctorData: DoctorMeStatsResponse;
+    appointments: AppointmentListItem[];
+  };
+
+  return (
+    <div data-testid="doctor-dashboard-page">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-foreground">
+          Welcome, Dr. {doctorData.user.firstName} {doctorData.user.lastName}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {doctorData.department.name} — {doctorData.specialization}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div
+          className="rounded-lg border border-border bg-card p-4 shadow-sm"
+          data-testid="stat-today-appointments"
+        >
+          <div className="flex items-center gap-3">
+            <Calendar className="h-5 w-5 text-primary" />
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Today's Appointments
+              </p>
+              <p className="mt-1 text-2xl font-bold text-card-foreground">
+                {doctorData.stats.todayAppointments}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="rounded-lg border border-border bg-card p-4 shadow-sm"
+          data-testid="stat-total-patients"
+        >
+          <div className="flex items-center gap-3">
+            <Users className="h-5 w-5 text-primary" />
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Total Patients
+              </p>
+              <p className="mt-1 text-2xl font-bold text-card-foreground">
+                {doctorData.stats.uniquePatients}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="rounded-lg border border-border bg-card p-4 shadow-sm"
+          data-testid="stat-total-appointments"
+        >
+          <div className="flex items-center gap-3">
+            <Clock className="h-5 w-5 text-primary" />
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Total Appointments
+              </p>
+              <p className="mt-1 text-2xl font-bold text-card-foreground">
+                {doctorData.stats.totalAppointments}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="rounded-lg border border-border bg-card p-4 shadow-sm"
+          data-testid="stat-rating"
+        >
+          <div className="flex items-center gap-3">
+            <Star className="h-5 w-5 text-primary" />
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Average Rating
+              </p>
+              <p className="mt-1 text-2xl font-bold text-card-foreground">
+                {doctorData.averageRating?.toFixed(1) ?? "—"}
+                {doctorData.averageRating && (
+                  <span className="text-sm font-normal text-muted-foreground">
+                    {" "}
+                    / 5
+                  </span>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">
+            Recent Appointments
+          </h2>
+          <Link
+            to="/appointments"
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            View all
+          </Link>
+        </div>
+
+        {appointments.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card p-6 text-center">
+            <p className="text-muted-foreground">No upcoming appointments</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {appointments.map((appointment) => (
+              <Link
+                key={appointment.id}
+                to={`/appointments/${appointment.id}`}
+                className="block rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-card-foreground">
+                      {appointment.patientName}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {appointment.appointmentDate} at {appointment.startTime}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full px-2 py-1 text-xs font-medium ${
+                      appointment.status === "completed"
+                        ? "bg-green-100 text-green-800"
+                        : appointment.status === "cancelled"
+                          ? "bg-red-100 text-red-800"
+                          : appointment.status === "confirmed"
+                            ? "bg-blue-100 text-blue-800"
+                            : "bg-yellow-100 text-yellow-800"
+                    }`}
+                  >
+                    {appointment.status}
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-8 rounded-lg border border-border bg-card p-6">
+        <h2 className="mb-4 text-lg font-semibold text-foreground">
+          Quick Actions
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          <Link to="/appointments">
+            <Button data-testid="btn-view-appointments">
+              <Calendar className="mr-2 h-4 w-4" />
+              View Appointments
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -6,9 +6,23 @@ import { loginSchema, type LoginInput } from "@caresync/shared";
 import { authApi, type ApiError } from "@/lib/api-client";
 import { useAuthStore } from "@/stores/auth-store";
 
+function getRoleDashboard(role: string): string {
+  switch (role) {
+    case "admin":
+      return "/admin";
+    case "doctor":
+      return "/doctor";
+    case "patient":
+      return "/dashboard";
+    default:
+      return "/dashboard";
+  }
+}
+
 export function LoginPage() {
   const navigate = useNavigate();
   const setAuth = useAuthStore((s) => s.setAuth);
+  const user = useAuthStore((s) => s.user);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated());
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -20,8 +34,8 @@ export function LoginPage() {
     resolver: zodResolver(loginSchema),
   });
 
-  if (isAuthenticated) {
-    return <Navigate to="/dashboard" replace />;
+  if (isAuthenticated && user) {
+    return <Navigate to={getRoleDashboard(user.role)} replace />;
   }
 
   const onSubmit = async (data: LoginInput) => {
@@ -29,7 +43,7 @@ export function LoginPage() {
     try {
       const { accessToken, user } = await authApi.login(data);
       setAuth(user, accessToken);
-      navigate("/dashboard", { replace: true });
+      navigate(getRoleDashboard(user.role), { replace: true });
     } catch (err) {
       const axiosError = err as ApiError;
       setServerError(axiosError.response?.data?.message ?? "Something went wrong. Please try again.");

--- a/apps/web/src/pages/register.tsx
+++ b/apps/web/src/pages/register.tsx
@@ -6,9 +6,23 @@ import { registerSchema, type RegisterInput } from "@caresync/shared";
 import { authApi, type ApiError } from "@/lib/api-client";
 import { useAuthStore } from "@/stores/auth-store";
 
+function getRoleDashboard(role: string): string {
+  switch (role) {
+    case "admin":
+      return "/admin";
+    case "doctor":
+      return "/doctor";
+    case "patient":
+      return "/dashboard";
+    default:
+      return "/dashboard";
+  }
+}
+
 export function RegisterPage() {
   const navigate = useNavigate();
   const setAuth = useAuthStore((s) => s.setAuth);
+  const user = useAuthStore((s) => s.user);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated());
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -21,8 +35,8 @@ export function RegisterPage() {
     defaultValues: { role: "patient" },
   });
 
-  if (isAuthenticated) {
-    return <Navigate to="/dashboard" replace />;
+  if (isAuthenticated && user) {
+    return <Navigate to={getRoleDashboard(user.role)} replace />;
   }
 
   const onSubmit = async (data: RegisterInput) => {
@@ -30,7 +44,7 @@ export function RegisterPage() {
     try {
       const { accessToken, user } = await authApi.register(data);
       setAuth(user, accessToken);
-      navigate("/dashboard", { replace: true });
+      navigate(getRoleDashboard(user.role), { replace: true });
     } catch (err) {
       const axiosError = err as ApiError;
       setServerError(axiosError.response?.data?.message ?? "Something went wrong. Please try again.");

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,4 +2,5 @@ export * from "./constants";
 export * from "./schemas/auth";
 export * from "./schemas/prescriptions";
 export * from "./schemas/admin";
+export * from "./schemas/doctors";
 export * from "./types";

--- a/packages/shared/src/schemas/doctors.ts
+++ b/packages/shared/src/schemas/doctors.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const doctorMeStatsSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  departmentId: z.string(),
+  specialization: z.string(),
+  bio: z.string().nullable(),
+  licenseNumber: z.string(),
+  averageRating: z.number().nullable(),
+  reviewCount: z.number(),
+  user: z.object({
+    id: z.string(),
+    email: z.string(),
+    role: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+    phone: z.string().nullable(),
+    avatarUrl: z.string().nullable(),
+  }),
+  department: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  stats: z.object({
+    totalAppointments: z.number(),
+    uniquePatients: z.number(),
+    todayAppointments: z.number(),
+  }),
+});
+
+export type DoctorMeStatsResponse = z.infer<typeof doctorMeStatsSchema>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -41,6 +41,14 @@ export interface Doctor {
   reviewCount: number;
 }
 
+export interface DoctorMeStats extends Doctor {
+  stats: {
+    totalAppointments: number;
+    uniquePatients: number;
+    todayAppointments: number;
+  };
+}
+
 export interface DoctorSchedule {
   id: string;
   doctorId: string;


### PR DESCRIPTION
- Add GET /doctors/me endpoint for doctor profile and stats
- Add DoctorDashboardPage at /doctor with stats and recent appointments
- Refactor patient dashboard (/dashboard) to show appointments, records, invoices
- Role-based login redirect: patient→/dashboard, doctor→/doctor, admin→/admin
- Replace inline PatientOnlyRoute/AdminOnlyRoute with reusable RoleOnlyRoute
- Root redirect goes to role-appropriate dashboard
- ProtectedRoute redirects unauthorized roles to their own dashboard
- Add shared DoctorMeStatsResponse schema