### PR TITLE
ci: optimize e2e workflow with sharding and reliability fixes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,18 +6,21 @@ on:
   pull_request:
     branches: [main, master]
 
-# Restrict default token permissions — deploy-pages job adds its own.
 permissions:
   contents: read
 
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
 
-      - name: Start Database
+      - name: Start services
         run: docker compose up -d
 
       - name: Setup pnpm
@@ -33,7 +36,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
 
@@ -48,9 +51,11 @@ jobs:
           pnpm --filter @caresync/api run db:migrate
           pnpm --filter @caresync/api run db:seed
 
+      - name: Wait for API
+        run: curl --retry 10 --retry-delay 3 --retry-connrefused http://localhost:3001/health
+
       - name: Get Playwright version
-        run: |
-          echo "PLAYWRIGHT_VERSION=$(pnpm ls @playwright/test --json | grep version | head -1 | tr -d '\",: ' | sed 's/version//')" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./node_modules/@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
       - name: Cache Playwright Browsers
         uses: actions/cache@v5
@@ -67,8 +72,8 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm --filter @caresync/e2e exec playwright install-deps chromium
 
-      - name: Run Playwright tests
-        run: pnpm test:e2e
+      - name: Run Playwright tests (shard ${{ matrix.shard }}/4)
+        run: pnpm test:e2e --shard=${{ matrix.shard }}/4
         env:
           ADMIN_EMAIL: admin@caresync.dev
           ADMIN_PASSWORD: Password123!
@@ -77,14 +82,13 @@ jobs:
         uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}
           path: apps/e2e/playwright-report/
           retention-days: 30
 
   deploy-pages:
     name: Deploy report to GitHub Pages
     needs: test
-    # Only deploy from the main branch — not from PRs or forks.
     if: always() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     permissions:
@@ -94,11 +98,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - name: Download Playwright report
+      - name: Download all reports
         uses: actions/download-artifact@v6
         with:
-          name: playwright-report
+          pattern: playwright-report-*
           path: playwright-report/
+          merge-multiple: true
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

- Add 4-shard matrix strategy for parallel test execution (~4x speedup)
- Fix Playwright version extraction (use `node` instead of brittle `grep/sed` pipeline)
- Fix Turborepo cache key (use `pnpm-lock.yaml` hash instead of `github.sha`)
- Add API health check wait before running tests
- Reduce timeout from 60 to 30 minutes
- Update deploy-pages to merge all shard reports using `merge-multiple: true`

## Changes

| Area | Before | After |
|------|--------|-------|
| Parallelism | 1 job, sequential | 4 shards running in parallel |
| Turborepo cache | Per-commit (ineffective) | Per-lockfile (effective) |
| Playwright version | Fragile grep/sed pipeline | Reliable `node -e` require |
| API readiness | Not checked | Health check with retries |
| Timeout | 60 min | 30 min |
| Report deployment | Single artifact | Merged multi-shard artifacts |